### PR TITLE
Update static LD flags to run on macOS

### DIFF
--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -4,7 +4,7 @@ package main
 // The -ldl is necessary to fix the linker errors about `dlsym` that would otherwise appear.
 
 /*
-#cgo LDFLAGS: ./lib/libhostbridge.a -ldl
+#cgo LDFLAGS: ./lib/libhostbridge.a -ldl -framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreVideo -framework IOKit -framework WebKit
 #include "../../lib/hostbridge.h"
 */
 import "C"


### PR DESCRIPTION
Added links to the required macOS frameworks in the static build to run on Monterey.