### PR TITLE
implement menu module basics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: ffi-static
 ffi-static:
-	cd lib/hostbridge && rustup run nightly cargo build --release
+	cd lib/hostbridge && cargo build --release
 	cp lib/hostbridge/target/release/libhostbridge.a lib/
 	CGO_LDFLAGS="./lib/libhostbridge.a -ldl -framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreVideo -framework IOKit -framework WebKit" \
 	go build -a -o ./ffi-debug ./cmd/ffi-debug/main_static.go

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: ffi-static
 ffi-static:
-	cd lib/hostbridge && cargo build --release
+	cd lib/hostbridge && rustup run nightly cargo build --release
 	cp lib/hostbridge/target/release/libhostbridge.a lib/
+	CGO_LDFLAGS="./lib/libhostbridge.a -ldl -framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreVideo -framework IOKit -framework WebKit" \
 	go build -a -o ./ffi-debug ./cmd/ffi-debug/main_static.go
 
 .PHONY: ffi-shared

--- a/bridge/app/app.go
+++ b/bridge/app/app.go
@@ -1,0 +1,91 @@
+package app
+
+/*
+#include "../../lib/hostbridge.h"
+*/
+import "C"
+
+import (
+	"os"
+	"unsafe"
+)
+
+import (
+	"github.com/progrium/hostbridge/bridge/window"
+)
+
+type Module struct {
+	shouldQuit  bool
+}
+
+type Callback func(event Event)
+
+type EventType int
+
+const (
+    EventNone       EventType = iota
+    EventClose
+    EventDestroyed
+    EventFocused
+    EventResized
+    EventMoved
+)
+
+func (e EventType) String() string {
+    return []string{"none", "close", "destroyed", "focused", "resized", "moved"}[e]
+}
+
+type Event struct {
+	Type       EventType
+	Name       string
+	WindowID   window.Handle
+	Position   window.Position
+	Size       window.Size
+}
+
+var module Module
+
+func init() {
+	module.shouldQuit = false
+}
+
+var userMainLoop Callback
+
+//export go_app_main_loop
+func go_app_main_loop(data C.Event) {
+	if (module.shouldQuit) {
+		return
+	}
+
+	if (userMainLoop != nil) {
+		event := Event{}
+		event.Type     = EventType(data.event_type)
+		event.Name     = event.Type.String()
+		event.WindowID = window.Handle(data.window_id)
+		event.Position = window.Position{ X: float64(data.position.x), Y: float64(data.position.y) }
+		event.Size     = window.Size{ Width: float64(data.size.width), Height: float64(data.size.height) }
+
+		userMainLoop(event)
+	}
+}
+
+func Run(callback Callback) {
+	if (callback != nil) {
+		userMainLoop = callback
+		eventLoop := *(*C.EventLoop)(unsafe.Pointer(&window.EventLoop))
+		C.run(eventLoop, C.closure(C.go_app_main_loop))
+	}
+}
+
+func Quit() {
+	if (!module.shouldQuit) {
+		module.shouldQuit = true
+
+		os.Exit(0)
+
+		// @Incomplete: ideally this would return execution to the main thread
+		// but it seems fine because ControlFlow::Exit actually quits the whole process...
+		//
+		// @MemoryLeak: window.EventLoop destructor needs to be called here if we return execution to go main
+	}
+}

--- a/bridge/app/app.go
+++ b/bridge/app/app.go
@@ -11,12 +11,9 @@ import (
 )
 
 import (
+	"github.com/progrium/hostbridge/bridge/menu"
 	"github.com/progrium/hostbridge/bridge/window"
 )
-
-type Module struct {
-	shouldQuit  bool
-}
 
 type Callback func(event Event)
 
@@ -41,6 +38,11 @@ type Event struct {
 	WindowID   window.Handle
 	Position   window.Position
 	Size       window.Size
+}
+
+type Module struct {
+	shouldQuit  bool
+	menu        menu.Menu
 }
 
 var module Module
@@ -88,4 +90,17 @@ func Quit() {
 		//
 		// @MemoryLeak: window.EventLoop destructor needs to be called here if we return execution to go main
 	}
+}
+
+func Menu() *menu.Menu {
+	if (menu.AppMenuWasSet) {
+		return &menu.AppMenu
+	}
+
+	return nil
+}
+
+func SetMenu(m menu.Menu) {
+	menu.AppMenu       = m
+	menu.AppMenuWasSet = true
 }

--- a/bridge/app/app.go
+++ b/bridge/app/app.go
@@ -20,16 +20,17 @@ type Callback func(event Event)
 type EventType int
 
 const (
-    EventNone       EventType = iota
-    EventClose
-    EventDestroyed
-    EventFocused
-    EventResized
-    EventMoved
+	EventNone       EventType = iota
+	EventClose
+	EventDestroyed
+	EventFocused
+	EventResized
+	EventMoved
+	EventMenuItem
 )
 
 func (e EventType) String() string {
-    return []string{"none", "close", "destroyed", "focused", "resized", "moved"}[e]
+	return []string{"none", "close", "destroyed", "focused", "resized", "moved", "menu-item"}[e]
 }
 
 type Event struct {
@@ -38,6 +39,7 @@ type Event struct {
 	WindowID   window.Handle
 	Position   window.Position
 	Size       window.Size
+	MenuID     uint16
 }
 
 type Module struct {
@@ -66,6 +68,7 @@ func go_app_main_loop(data C.Event) {
 		event.WindowID = window.Handle(data.window_id)
 		event.Position = window.Position{ X: float64(data.position.x), Y: float64(data.position.y) }
 		event.Size     = window.Size{ Width: float64(data.size.width), Height: float64(data.size.height) }
+		event.MenuID   = uint16(data.menu_id)
 
 		userMainLoop(event)
 	}

--- a/bridge/menu/menu.go
+++ b/bridge/menu/menu.go
@@ -1,0 +1,82 @@
+package menu
+
+/*
+#include "../../lib/hostbridge.h"
+*/
+import "C"
+
+import (
+)
+
+type Handle int
+
+type Menu struct {
+  /*
+	Items []Item
+  */
+
+  Handle C.Menu
+}
+
+type Item struct {
+  ID          uint16
+  Title       string
+  Enabled     bool
+  Selected    bool
+  Accelerator string
+
+  /*
+  Role        string // for wry's add_native_item (see Electron's MenuItem role for examples)
+  Type        string // normal, separator, submenu, checkbox or radio
+  Checked     bool   // for checkbox or radio types
+  */
+
+  SubMenu     []Item
+}
+
+var AppMenu       Menu
+var AppMenuWasSet bool
+
+func init() {
+  AppMenuWasSet = false
+}
+
+func New(items []Item) Menu {
+  menu := C.menu_create()
+
+  for _, it := range items {
+    if (len(it.SubMenu) > 0) {
+      submenu := New(it.SubMenu)
+      C.menu_add_submenu(menu, C.CString(it.Title), toCBool(true), submenu.Handle)
+    } else {
+      C.menu_add_item(menu, buildCMenuItem(it))
+    }
+  }
+
+  result := Menu{}
+  result.Handle = menu
+
+	return result
+}
+
+func buildCMenuItem(item Item) C.Menu_Item {
+  return C.Menu_Item {
+    id:          C.int(item.ID),
+    title:       C.CString(item.Title),
+    enabled:     toCBool(item.Enabled),
+    selected:    toCBool(item.Selected),
+    accelerator: C.CString(item.Accelerator),
+  }
+}
+
+func toCBool(it bool) C.uchar {
+  if (it) {
+    return C.uchar(1)
+  }
+
+  return C.uchar(0)
+}
+
+func toBool(it C.uchar) bool {
+  return int(it) != 0
+}

--- a/bridge/menu/menu.go
+++ b/bridge/menu/menu.go
@@ -5,78 +5,75 @@ package menu
 */
 import "C"
 
-import (
-)
-
 type Handle int
 
 type Menu struct {
-  /*
+	/*
 	Items []Item
-  */
+	*/
 
-  Handle C.Menu
+	Handle C.Menu
 }
 
 type Item struct {
-  ID          uint16
-  Title       string
-  Enabled     bool
-  Selected    bool
-  Accelerator string
+	ID          uint16
+	Title       string
+	Enabled     bool
+	Selected    bool
+	Accelerator string
 
-  /*
-  Role        string // for wry's add_native_item (see Electron's MenuItem role for examples)
-  Type        string // normal, separator, submenu, checkbox or radio
-  Checked     bool   // for checkbox or radio types
-  */
+	/*
+	Role        string // for wry's add_native_item (see Electron's MenuItem role for examples)
+	Type        string // normal, separator, submenu, checkbox or radio
+	*/
 
-  SubMenu     []Item
+	SubMenu     []Item
 }
 
 var AppMenu       Menu
 var AppMenuWasSet bool
 
 func init() {
-  AppMenuWasSet = false
+	AppMenu = New([]Item {})
+	AppMenuWasSet = false
 }
 
 func New(items []Item) Menu {
-  menu := C.menu_create()
+	menu := C.menu_create()
 
-  for _, it := range items {
-    if (len(it.SubMenu) > 0) {
-      submenu := New(it.SubMenu)
-      C.menu_add_submenu(menu, C.CString(it.Title), toCBool(true), submenu.Handle)
-    } else {
-      C.menu_add_item(menu, buildCMenuItem(it))
-    }
-  }
+	for _, it := range items {
+		if (len(it.SubMenu) > 0) {
+			submenu := New(it.SubMenu)
+			C.menu_add_submenu(menu, C.CString(it.Title), toCBool(it.Enabled), submenu.Handle)
+		} else {
+			C.menu_add_item(menu, buildCMenuItem(it))
+		}
+	}
 
-  result := Menu{}
-  result.Handle = menu
+	result := Menu{}
+	result.Handle = menu
 
 	return result
 }
 
 func buildCMenuItem(item Item) C.Menu_Item {
-  return C.Menu_Item {
-    id:          C.int(item.ID),
-    title:       C.CString(item.Title),
-    enabled:     toCBool(item.Enabled),
-    selected:    toCBool(item.Selected),
-    accelerator: C.CString(item.Accelerator),
-  }
+	return C.Menu_Item {
+		id:          C.int(item.ID),
+		title:       C.CString(item.Title),
+		enabled:     toCBool(item.Enabled),
+		selected:    toCBool(item.Selected),
+		accelerator: C.CString(item.Accelerator),
+	}
 }
 
 func toCBool(it bool) C.uchar {
-  if (it) {
-    return C.uchar(1)
-  }
+	if (it) {
+		return C.uchar(1)
+	}
 
-  return C.uchar(0)
+	return C.uchar(0)
 }
 
 func toBool(it C.uchar) bool {
-  return int(it) != 0
+	return int(it) != 0
 }

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -139,7 +139,6 @@ func Create(options Options) (*Window, error) {
 
 	appMenu := *(*C.Menu)(unsafe.Pointer(&menu.AppMenu))
 	result := C.window_create(EventLoop, opts, appMenu)
-	//result := -1
 	id := int(result)
 
 	window := Window{}

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -1,10 +1,8 @@
 package window
 
 // NOTE: There should be NO space between the comments and the `import "C"` line.
-// The -ldl is necessary to fix the linker errors about `dlsym` that would otherwise appear.
 
 /*
-#cgo LDFLAGS: ./lib/libhostbridge.a -ldl -framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreVideo -framework IOKit -framework WebKit
 #include "../../lib/hostbridge.h"
 */
 import "C"

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -3,8 +3,9 @@ package main
 import "fmt"
 
 import (
-	"github.com/progrium/hostbridge/bridge/window"
 	"github.com/progrium/hostbridge/bridge/app"
+	"github.com/progrium/hostbridge/bridge/menu"
+	"github.com/progrium/hostbridge/bridge/window"
 )
 
 func tick(event app.Event) {
@@ -28,6 +29,36 @@ func tick(event app.Event) {
 }
 
 func main() {
+	items := []menu.Item {
+		{
+			ID: 12,
+			Title: "First Menu",
+			Enabled: true,
+			SubMenu: []menu.Item {
+				{
+					ID: 121,
+					Title: "About",
+					Enabled: true,
+				},
+			},
+		},
+		{
+			ID: 23,
+			Title: "hello world",
+			Enabled: true,
+			SubMenu: []menu.Item {
+				{
+					ID: 121,
+					Title: "About2",
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	m := menu.New(items)
+	app.SetMenu(m)
+
 	options := window.Options{
 		// NOTE(nick): resizing a transparent window on MacOS seems really slow?
 		// Transparent: true,

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -25,20 +25,47 @@ func tick(event app.Event) {
 				app.Quit()
 			}
 		}
+
+		if (event.Name == "menu-item") {
+			w := window.FindByID(event.WindowID)
+			if (w != nil) {
+				w.Destroy()
+			}
+
+			all := window.All()
+			fmt.Println("count of all windows", len(all))
+			if (len(all) == 0) {
+				fmt.Println("  quitting application...")
+				app.Quit()
+			}
+		}
 	}
 }
 
 func main() {
 	items := []menu.Item {
 		{
-			ID: 12,
-			Title: "First Menu",
+			// NOTE(nick): when setting the window menu with wry, the first item title will always be the name of the executable on MacOS
+			// so, this property is ignored:
+			// @Robustness: maybe we want to make that more visible to the user somehow?
+			Title: "this doesnt matter",
 			Enabled: true,
 			SubMenu: []menu.Item {
 				{
 					ID: 121,
 					Title: "About",
 					Enabled: true,
+				},
+				{
+					ID: 122,
+					Title: "Disabled",
+					Enabled: false,
+				},
+				{
+					ID: 99,
+					Title: "Quit",
+					Enabled: true,
+					//Accelerator: "CommandOrControl+Q",
 				},
 			},
 		},
@@ -48,7 +75,7 @@ func main() {
 			Enabled: true,
 			SubMenu: []menu.Item {
 				{
-					ID: 121,
+					ID: 777,
 					Title: "About2",
 					Enabled: true,
 				},
@@ -64,15 +91,16 @@ func main() {
 		// Transparent: true,
 		// Frameless: false,
 		HTML: `
-          <!doctype html>
-          <html>
-            <body style="font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif; background-color:rgba(87,87,87,0.8);"></body>
-            <script>
-              window.onload = function() {
-                document.body.innerHTML = '<div style="padding: 30px">Transparency Test<br><br>${navigator.userAgent}</div>';
-              };
-            </script>
-          </html>`,
+			<!doctype html>
+			<html>
+				<body style="font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif; background-color:rgba(87,87,87,0.8);"></body>
+				<script>
+					window.onload = function() {
+						document.body.innerHTML = '<div style="padding: 30px">Transparency Test<br><br>${navigator.userAgent}</div>';
+					};
+				</script>
+			</html>
+		`,
 	};
 
 	w1, _ := window.Create(options)

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -1,9 +1,13 @@
 package main
 
 import "fmt"
-import "github.com/progrium/hostbridge/bridge/window"
 
-func tick(event window.Event) {
+import (
+	"github.com/progrium/hostbridge/bridge/window"
+	"github.com/progrium/hostbridge/bridge/app"
+)
+
+func tick(event app.Event) {
 	if (event.Type > 0) {
 		fmt.Println("[tick] event", event)
 
@@ -17,7 +21,7 @@ func tick(event window.Event) {
 			fmt.Println("count of all windows", len(all))
 			if (len(all) == 0) {
 				fmt.Println("  quitting application...")
-				window.Quit()
+				app.Quit()
 			}
 		}
 	}
@@ -44,6 +48,10 @@ func main() {
 
 	fmt.Println("[main] window", w1)
 
+	if (w1 == nil) {
+		return
+	}
+
 	w1.SetTitle("Hello, Sailor!")
 	fmt.Println("[main] window position", w1.GetOuterPosition())
 
@@ -55,7 +63,7 @@ func main() {
 	wasDestroyed := w2.Destroy()
 	fmt.Println("[main] wasDestroyed", wasDestroyed)
 
-	window.Run(tick)
+	app.Run(tick)
 
 	// NOTE(nick): this doesn't appear to be called ever
 	fmt.Println("[main] Goodbye.", w1)

--- a/lib/hostbridge.h
+++ b/lib/hostbridge.h
@@ -23,6 +23,7 @@ typedef enum EventType {
 	EventFocused   = 3,
 	EventResized   = 4,
 	EventMoved     = 5,
+	EventMenuItem  = 6,
 } EventType;
 
 typedef struct Event {
@@ -30,6 +31,7 @@ typedef struct Event {
 	int      window_id;
 	Position position;
 	Size     size;
+	int      menu_id;
 } Event;
 
 // NOTE(nick): this has to be kept in sync with wry's EventLoop struct size

--- a/lib/hostbridge.h
+++ b/lib/hostbridge.h
@@ -37,11 +37,24 @@ typedef struct EventLoop {
 	unsigned char data[40];
 } EventLoop;
 
+// NOTE(nick): this has to be kept in sync with wry's Menu struct size
+typedef struct Menu {
+	unsigned char data[16];
+} Menu;
+
 typedef struct Window_Options {
 	bool transparent;
 	bool decorations;
 	char *html;
 } Window_Options;
+
+typedef struct Menu_Item {
+	int  id;
+	char *title;
+	bool enabled;
+	bool selected;
+	char *accelerator;
+} Menu_Item;
 
 //
 // Go Functions
@@ -57,7 +70,7 @@ void go_app_main_loop();
 
 EventLoop create_event_loop();
 
-int      window_create(EventLoop event_loop, Window_Options options);
+int      window_create(EventLoop event_loop, Window_Options options, Menu menu);
 bool     window_destroy(int window_id);
 bool     window_set_title(int window_id, char *title);
 bool     window_set_visible(int window_id, bool is_visible);
@@ -68,4 +81,10 @@ Position window_get_inner_position(int window_id);
 Size     window_get_inner_size(int window_id);
 double   window_get_dpi_scale(int window_id);
 
+Menu menu_create();
+bool menu_add_item(Menu menu, Menu_Item item);
+bool menu_add_submenu(Menu menu, char *title, bool enabled, Menu submenu);
+bool menu_set_application_menu(Menu menu);
+
 void run(EventLoop event_loop, void (*callback)(Event event));
+

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -98,23 +98,23 @@ macro_rules! find_local_window {
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn create_event_loop() -> CEventLoop {
-  //
-  // NOTE(nick): If this changes, go and update hostbridge.h EventLoop size
-  // @Robustness: make this a static assertion
-  //
-  assert_eq!(size_of::<CEventLoop>(), 40);
+	//
+	// NOTE(nick): If this changes, go and update hostbridge.h EventLoop size
+	// @Robustness: make this a static assertion
+	//
+	assert_eq!(size_of::<CEventLoop>(), 40);
 
-  let result = EventLoop::new();
-  
-  //
-  // NOTE(nick): prevent the EventLoop's destructor from being called here
-  // Other places that take the event_loop as an argument will also need to call `std::mem::forget`
-  //
-  let mut r2 = ManuallyDrop::new(result);
+	let result = EventLoop::new();
+	
+	//
+	// NOTE(nick): prevent the EventLoop's destructor from being called here
+	// Other places that take the event_loop as an argument will also need to call `std::mem::forget`
+	//
+	let mut r2 = ManuallyDrop::new(result);
 
-  unsafe {
-	ManuallyDrop::take(&mut r2)
-  }
+	unsafe {
+		ManuallyDrop::take(&mut r2)
+	}
 }
 
 #[no_mangle]


### PR DESCRIPTION
Done:
- created `app` and `menu` modules (moved `window.Run` and `window.Quit` to `app.Run` and `app.Quit`)
- added `MenuItem` event
- moved CGO_LDFLAGS to command line argument (to not repeat it everywhere and help with making this compile cross platform)

Not done:
- parsing Accelerator strings into wry Accelerator structs
- menu `type` attribute (wry doesn't seem to have this as a part of their API)
- menu `role` attribute to do native system stuff (similar to https://www.electronjs.org/docs/latest/api/menu-item#roles)