### PR TITLE
win32 tray menu working

### DIFF
--- a/lib/hostbridge.h
+++ b/lib/hostbridge.h
@@ -6,6 +6,15 @@
 
 #define bool uint8_t
 
+#if defined(_WIN32)
+  #define OS_WINDOWS 1
+#elif defined(__APPLE__)
+  #define OS_MACOS 1
+#else
+  //#define OS_LINUX 1
+  #error "[os.h] Unsuported operating system!"
+#endif
+
 typedef struct Position {
 	double x;
 	double y;
@@ -41,12 +50,20 @@ typedef struct EventLoop {
 
 // NOTE(nick): this has to be kept in sync with wry's Menu struct size
 typedef struct Menu {
+	#ifdef OS_MACOS
 	unsigned char data[16];
+	#elif OS_WINDOWS
+	unsigned char data[64];
+	#endif
 } Menu;
 
 // NOTE(nick): this has to be kept in sync with wry's ContextMenu struct size
 typedef struct ContextMenu {
+	#ifdef OS_MACOS
 	unsigned char data[16];
+	#elif OS_WINDOWS
+	unsigned char data[64];
+	#endif
 } ContextMenu;
 
 typedef struct Window_Options {

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -292,6 +292,9 @@ pub extern "C" fn menu_create() -> CMenu {
 	// NOTE(nick): If this changes, go and update hostbridge.h Menu size
 	// @Robustness: make this a static assertion
 	//
+	#[cfg(target_os = "macos")]
+	assert_eq!(size_of::<CMenu>(), 16);
+	#[cfg(target_os = "windows")]
 	assert_eq!(size_of::<CMenu>(), 64);
 
 	let result = MenuBar::new();
@@ -365,6 +368,9 @@ pub extern "C" fn context_menu_create() -> CContextMenu {
 	// NOTE(nick): If this changes, go and update hostbridge.h Menu size
 	// @Robustness: make this a static assertion
 	//
+	#[cfg(target_os = "macos")]
+	assert_eq!(size_of::<CContextMenu>(), 16);
+	#[cfg(target_os = "windows")]
 	assert_eq!(size_of::<CContextMenu>(), 64);
 
 	let result = CContextMenu::new();
@@ -449,8 +455,8 @@ pub extern "C" fn tray_set_system_tray(event_loop: CEventLoop, icon: CIcon, tray
 	// you can call system_tray.set_icon to change the icon dynamically
 
 	forget(event_loop);
-	forget(icon);
-	forget(system_tray);
+	forget(icon); // NOTE(nick): prevent rust from trying to dealloc something it doesn't own
+	forget(system_tray); // @MemoryLeak
 
 	true
 }

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -292,7 +292,7 @@ pub extern "C" fn menu_create() -> CMenu {
 	// NOTE(nick): If this changes, go and update hostbridge.h Menu size
 	// @Robustness: make this a static assertion
 	//
-	assert_eq!(size_of::<CMenu>(), 16);
+	assert_eq!(size_of::<CMenu>(), 64);
 
 	let result = MenuBar::new();
 	
@@ -365,7 +365,7 @@ pub extern "C" fn context_menu_create() -> CContextMenu {
 	// NOTE(nick): If this changes, go and update hostbridge.h Menu size
 	// @Robustness: make this a static assertion
 	//
-	assert_eq!(size_of::<CContextMenu>(), 16);
+	assert_eq!(size_of::<CContextMenu>(), 64);
 
 	let result = CContextMenu::new();
 	
@@ -443,15 +443,14 @@ pub extern "C" fn context_menu_add_submenu(mut menu: CContextMenu, title: CStrin
 pub extern "C" fn tray_set_system_tray(event_loop: CEventLoop, icon: CIcon, tray_menu: CContextMenu) -> CBool {
 	let icon = unsafe { Vec::<u8>::from_raw_parts(icon.data, icon.size as usize, icon.size as usize) };
 
-	// NOTE(nick): confusingly, calling SystemTrayBuilder::new also sets it as the active system tray
-	// ideally we would probably want these two concepets to be decoupled in the future?
-	let _system_tray = SystemTrayBuilder::new(icon.clone(), Some(tray_menu)).build(&event_loop).unwrap();
+	let system_tray = SystemTrayBuilder::new(icon.clone(), Some(tray_menu)).build(&event_loop).unwrap();
 
-	// @Incomplete: in the future we will want to store teh system_tray somewhere (probably in Go), so that
+	// @Incomplete: in the future we will want to store the system_tray somewhere (probably in Go), so that
 	// you can call system_tray.set_icon to change the icon dynamically
 
 	forget(event_loop);
 	forget(icon);
+	forget(system_tray);
 
 	true
 }


### PR DESCRIPTION
Had to `forget` the `system_tray` instance so it doesn't GC'd on windows

Had to switch on operating system to set the right struct sizes for the wry `Menu` and `ContextMenu` objects for MacOS and windows. So now the `build.bat` works without any extra tweaking of source files!