### PR TITLE
bridge: working bridge test, refactor window to use module instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: ffi-static
-ffi-static:
-	cd lib/hostbridge && cargo build --release
-	cp lib/hostbridge/target/release/libhostbridge.a lib/
+ffi-static: lib/libhostbridge.a
 	CGO_LDFLAGS="./lib/libhostbridge.a -ldl -framework Carbon -framework Cocoa -framework CoreFoundation -framework CoreVideo -framework IOKit -framework WebKit" \
 	go build -a -o ./ffi-debug ./cmd/ffi-debug/main_static.go
 
 .PHONY: ffi-shared
-ffi-shared:
+ffi-shared: lib/libhostbridge.dylib
+	go build -a -o ./ffi-debug -ldflags="-r $(ROOT_DIR)lib" ./cmd/ffi-debug/main_shared.go
+
+lib/libhostbridge.dylib:
 	cd lib/hostbridge && cargo build --release
 	cp lib/hostbridge/target/release/libhostbridge.dylib lib/
-	go build -a -o ./ffi-debug -ldflags="-r $(ROOT_DIR)lib" ./cmd/ffi-debug/main_shared.go
+
+lib/libhostbridge.a:
+	cd lib/hostbridge && cargo build --release
+	cp lib/hostbridge/target/release/libhostbridge.a lib/
 
 .PHONY: clean
 clean:

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,17 +1,41 @@
 package bridge
 
 import (
+	"unsafe"
+
+	"github.com/mitchellh/mapstructure"
 	"github.com/progrium/qtalk-go/codec"
 	"github.com/progrium/qtalk-go/fn"
 	"github.com/progrium/qtalk-go/rpc"
 
+	"github.com/progrium/hostbridge/bridge/app"
 	"github.com/progrium/hostbridge/bridge/window"
 )
+
+type ret struct {
+	V interface{}
+	E error
+}
 
 func NewServer() *rpc.Server {
 	mux := rpc.NewRespondMux()
 
-	mux.Handle("window", fn.HandlerFrom(&window.Module{}))
+	// most of this cruft can be eliminated when qtalk gets mapstructure support
+	// and libhostbridge becomes thread-safe.
+	mux.Handle("window.Create", fn.HandlerFrom(func(opts map[string]interface{}) (uintptr, error) {
+		var wopts window.Options
+		err := mapstructure.Decode(opts, &wopts)
+		if err != nil {
+			return 0, err
+		}
+		rchan := make(chan ret)
+		app.Dispatch(func() {
+			w, err := window.Create(wopts)
+			rchan <- ret{V: w, E: err}
+		})
+		r := <-rchan
+		return uintptr(unsafe.Pointer(r.V.(*window.Window))), r.E
+	}))
 
 	return &rpc.Server{
 		Codec:   codec.JSONCodec{},

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -1,0 +1,64 @@
+package bridge
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/progrium/hostbridge/bridge/app"
+	"github.com/progrium/hostbridge/bridge/window"
+	"github.com/progrium/qtalk-go/codec"
+	"github.com/progrium/qtalk-go/fn"
+	"github.com/progrium/qtalk-go/talk"
+)
+
+func init() {
+	runtime.LockOSThread()
+}
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	go func() {
+		m.Run()
+		app.Quit()
+	}()
+	app.Run(nil)
+}
+
+func TestBridge(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewServer()
+	go srv.Serve(l)
+
+	client, err := talk.Dial("tcp", l.Addr().String(), codec.JSONCodec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var opts interface{}
+	opts = window.Options{
+		HTML: `
+			<!doctype html>
+			<html>
+				<body style="font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif; background-color:rgba(87,87,87,0.8);"></body>
+				<script>
+					window.onload = function() {
+						document.body.innerHTML = '<div style="padding: 30px">TEST</div>';
+					};
+				</script>
+			</html>
+		`,
+	}
+	_, err = client.Call(context.Background(), "window.Create", fn.Args{opts}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// uncomment to see visually
+	time.Sleep(1 * time.Second)
+}

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -8,20 +8,18 @@ package window
 import "C"
 
 import (
-	"sync"
 	"errors"
+	"sync"
 	"unsafe"
-)
 
-import (
 	"github.com/progrium/hostbridge/bridge/menu"
 )
 
-type Module struct {
+type module struct {
 	mu sync.Mutex
 
-	windows     []Window
-	shouldQuit  bool
+	windows    []Window
+	shouldQuit bool
 }
 
 type Position struct {
@@ -42,16 +40,16 @@ type Window struct {
 	Transparent bool
 
 	/*
-	Size        Size
-	Position    Position
-	AlwaysOnTop bool
-	Fullscreen  bool
-	MinSize     Size
-	MaxSize     Size
-	Resizable   bool
+		Size        Size
+		Position    Position
+		AlwaysOnTop bool
+		Fullscreen  bool
+		MinSize     Size
+		MaxSize     Size
+		Resizable   bool
 	*/
 
-	destroyed   bool
+	destroyed bool
 }
 
 type Options struct {
@@ -60,42 +58,43 @@ type Options struct {
 	HTML        string
 
 	/*
-	AlwaysOnTop bool
-	Size        Size
-	MinSize     Size
-	MaxSize     Size
-	Maximized   bool
-	Position    Position
-	Resizable   bool
-	Title       string
-	Transparent bool
-	Visible     bool
-	Center      bool
-	Icon        string // bytestream callback
-	URL         string
-	Script      string
+		AlwaysOnTop bool
+		Size        Size
+		MinSize     Size
+		MaxSize     Size
+		Maximized   bool
+		Position    Position
+		Resizable   bool
+		Title       string
+		Transparent bool
+		Visible     bool
+		Center      bool
+		Icon        string // bytestream callback
+		URL         string
+		Script      string
 	*/
 }
 
 var EventLoop C.EventLoop
+var Module *module
 
 func init() {
 	EventLoop = C.create_event_loop()
-}
-
-var module Module
-
-func init() {
+	Module = &module{}
 }
 
 func All() (result []Window) {
+	return Module.All()
+}
+
+func (m *module) All() (result []Window) {
 	/*
-	module.mu.Lock()
-	defer module.mu.Unlock()
+		module.mu.Lock()
+		defer module.mu.Unlock()
 	*/
 
-	for _, it := range module.windows {
-		if (!it.destroyed) {
+	for _, it := range m.windows {
+		if !it.destroyed {
 			result = append(result, it)
 		}
 	}
@@ -103,15 +102,15 @@ func All() (result []Window) {
 	return result
 }
 
-func FindIndexByID(windowID Handle) int {
+func (m *module) FindIndexByID(windowID Handle) int {
 	/*
-	module.mu.Lock()
-	defer module.mu.Unlock()
+		module.mu.Lock()
+		defer module.mu.Unlock()
 	*/
 
 	var result int = -1
 
-	for i, v := range module.windows {
+	for i, v := range m.windows {
 		if v.ID == windowID {
 			result = i
 			break
@@ -121,50 +120,57 @@ func FindIndexByID(windowID Handle) int {
 	return result
 }
 
-func FindByID(windowID Handle) *Window {
-	index := FindIndexByID(windowID)
-	if (index >= 0) {
-		return &module.windows[index]
+func (m *module) FindByID(windowID Handle) *Window {
+	index := m.FindIndexByID(windowID)
+	if index >= 0 {
+		return &m.windows[index]
 	}
 	return nil
 }
 
 func Create(options Options) (*Window, error) {
+	return Module.Create(options)
+}
+
+func (m *module) Create(options Options) (*Window, error) {
 	opts := C.Window_Options{
 		transparent: toCBool(options.Transparent),
 		decorations: toCBool(!options.Frameless),
-		html: C.CString(options.HTML),
-	};
-
+		html:        C.CString(options.HTML),
+	}
 
 	appMenu := *(*C.Menu)(unsafe.Pointer(&menu.AppMenu))
 	result := C.window_create(EventLoop, opts, appMenu)
 	id := int(result)
 
 	window := Window{}
-	window.ID          = Handle(id)
+	window.ID = Handle(id)
 	window.Transparent = options.Transparent
 
-	if (id >= 0) {
-		module.windows = append(module.windows, window)
+	if id >= 0 {
+		m.windows = append(m.windows, window)
 		return &window, nil
 	}
 
 	return nil, errors.New("Failed to create window")
 }
 
+func (m *module) Destroy(w *Window) bool {
+	return w.Destroy()
+}
+
 func (it *Window) Destroy() bool {
 	result := false
 
-	if (!it.destroyed) {
+	if !it.destroyed {
 		success := C.window_destroy(C.int(it.ID))
-		if (toBool(success)) {
+		if toBool(success) {
 			it.destroyed = true
 			result = true
 
-			index := FindIndexByID(it.ID)
-			if (index >= 0) {
-				module.windows = append(module.windows[:index], module.windows[index+1:]...)
+			index := Module.FindIndexByID(it.ID)
+			if index >= 0 {
+				Module.windows = append(Module.windows[:index], Module.windows[index+1:]...)
 			}
 		}
 	}
@@ -172,37 +178,61 @@ func (it *Window) Destroy() bool {
 	return result
 }
 
+func (m *module) IsDestroyed(w *Window) bool {
+	return w.IsDestroyed()
+}
+
 func (it *Window) IsDestroyed() bool {
 	return it.destroyed
 }
 
+func (m *module) SetTitle(w *Window, title string) {
+	w.SetTitle(title)
+}
+
 func (it *Window) SetTitle(title string) {
 	success := C.window_set_title(C.int(it.ID), C.CString(title))
-	if (toBool(success)) {
+	if toBool(success) {
 		it.Title = title
 	}
+}
+
+func (m *module) SetVisible(w *Window, visible bool) {
+	w.SetVisible(visible)
 }
 
 func (it *Window) SetVisible(visible bool) {
 	C.window_set_visible(C.int(it.ID), toCBool(visible))
 }
 
+func (m *module) SetFullscreen(w *Window, fullscreen bool) {
+	w.SetFullscreen(fullscreen)
+}
+
 func (it *Window) SetFullscreen(fullscreen bool) {
 	C.window_set_fullscreen(C.int(it.ID), toCBool(fullscreen))
 }
 
+func (m *module) GetOuterPosition(w *Window) Position {
+	return w.GetOuterPosition()
+}
+
 func (it *Window) GetOuterPosition() Position {
 	result := C.window_get_outer_position(C.int(it.ID))
-	return Position{ X: float64(result.x), Y: float64(result.y) }
+	return Position{X: float64(result.x), Y: float64(result.y)}
+}
+
+func (m *module) GetOuterSize(w *Window) Size {
+	return w.GetOuterSize()
 }
 
 func (it *Window) GetOuterSize() Size {
 	result := C.window_get_outer_size(C.int(it.ID))
-	return Size{ Width: float64(result.width), Height: float64(result.height) }
+	return Size{Width: float64(result.width), Height: float64(result.height)}
 }
 
 func toCBool(it bool) C.uchar {
-	if (it) {
+	if it {
 		return C.uchar(1)
 	}
 

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"runtime"
-)
 
-import (
 	"github.com/progrium/hostbridge/bridge/app"
 	"github.com/progrium/hostbridge/bridge/menu"
 	"github.com/progrium/hostbridge/bridge/window"
@@ -16,79 +14,79 @@ var quitId uint16 = 999
 var quitAllId uint16 = 9999
 
 func tick(event app.Event) {
-	if (event.Type > 0) {
+	if event.Type > 0 {
 		fmt.Println("[tick] event", event)
 
-		if (event.Name == "close") {
-			w := window.FindByID(event.WindowID)
-			if (w != nil) {
+		if event.Name == "close" {
+			w := window.Module.FindByID(event.WindowID)
+			if w != nil {
 				w.Destroy()
 			}
 
-			all := window.All()
+			all := window.Module.All()
 			fmt.Println("count of all windows", len(all))
-			if (len(all) == 0) {
+			if len(all) == 0 {
 				fmt.Println("  quitting application...")
 				app.Quit()
 			}
 		}
 
-		if (event.Name == "menu-item" && event.MenuID == quitId) {
-			w := window.FindByID(event.WindowID)
-			if (w != nil) {
+		if event.Name == "menu-item" && event.MenuID == quitId {
+			w := window.Module.FindByID(event.WindowID)
+			if w != nil {
 				w.Destroy()
 			}
 
-			all := window.All()
+			all := window.Module.All()
 			fmt.Println("count of all windows", len(all))
-			if (len(all) == 0) {
+			if len(all) == 0 {
 				fmt.Println("  quitting application...")
 				app.Quit()
 			}
 		}
 
-		if (event.Name == "menu-item" && event.MenuID == quitAllId) {
+		if event.Name == "menu-item" && event.MenuID == quitAllId {
 			app.Quit()
 		}
 	}
 }
 
 func main() {
-	menuTemplate := []menu.Item {
+	menuTemplate := []menu.Item{
 		{
 			// NOTE(nick): when setting the window menu with wry, the first item title will always be the name of the executable on MacOS
 			// so, this property is ignored:
 			// @Robustness: maybe we want to make that more visible to the user somehow?
-			Title: "this doesnt matter",
+			Title:   "this doesnt matter",
 			Enabled: true,
-			SubMenu: []menu.Item {
+			SubMenu: []menu.Item{
 				{
-					ID: 121,
-					Title: "About",
-					Enabled: true,
+					ID:          121,
+					Title:       "About",
+					Enabled:     true,
 					Accelerator: "Control+I",
 				},
 				{
-					ID: 122,
-					Title: "Disabled",
+					ID:      122,
+					Title:   "Disabled",
 					Enabled: false,
 				},
 				{
-					ID: quitId,
-					Title: "Quit",
-					Enabled: true,
+					ID:          quitId,
+					Title:       "Quit",
+					Enabled:     true,
 					Accelerator: "CommandOrControl+Q",
 				},
 			},
 		},
 		{
-			ID: 23,
-			Title: "hello world",
+			ID:      23,
+			Title:   "hello world",
 			Enabled: true,
-			SubMenu: []menu.Item {
+			SubMenu: []menu.Item{
 				{
-					ID: 777,
-					Title: "This is an amazing menu option",
+					ID:      777,
+					Title:   "This is an amazing menu option",
 					Enabled: true,
 				},
 			},
@@ -98,81 +96,80 @@ func main() {
 	m := menu.New(menuTemplate)
 	app.SetMenu(m)
 
-	trayTemplate := []menu.Item {
+	trayTemplate := []menu.Item{
 		{
-			Title: "Click on this here thing",
+			Title:   "Click on this here thing",
 			Enabled: true,
 		},
 		{
-			Title: "Secret stuff",
+			Title:   "Secret stuff",
 			Enabled: true,
-			SubMenu: []menu.Item {
+			SubMenu: []menu.Item{
 				{
-					ID: 42,
-					Title: "I'm nested!!",
+					ID:      42,
+					Title:   "I'm nested!!",
 					Enabled: true,
 				},
 				{
-					ID: 101,
-					Title: "Can't touch this",
+					ID:      101,
+					Title:   "Can't touch this",
 					Enabled: false,
 				},
 			},
 		},
 		{
-			ID: quitAllId,
-			Title: "Quit App",
-			Enabled: true,
+			ID:          quitAllId,
+			Title:       "Quit App",
+			Enabled:     true,
 			Accelerator: "Command+T",
 		},
 	}
 
-	iconPath 	:= "assets/icon.png"
+	iconPath := "assets/icon.png"
 	if runtime.GOOS == "windows" {
 		iconPath = "assets/icon.ico"
 	}
 
 	iconData, err := ioutil.ReadFile(iconPath)
-	if (err != nil) {
+	if err != nil {
 		fmt.Println("Error reading icon file:", err)
 	}
-	
+
 	app.NewIndicator(iconData, trayTemplate)
 
 	options := window.Options{
 		// NOTE(nick): resizing a transparent window on MacOS seems really slow?
-		// Transparent: true,
-		// Frameless: false,
+		//Transparent: true,
+		Frameless: false,
 		HTML: `
 			<!doctype html>
 			<html>
 				<body style="font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif; background-color:rgba(87,87,87,0.8);"></body>
 				<script>
 					window.onload = function() {
-						document.body.innerHTML = '<div style="padding: 30px">Transparency Test<br><br>${navigator.userAgent}</div>';
+						document.body.innerHTML = '<div style="padding: 30px">Transparency Test!<br><br>${navigator.userAgent}</div>';
 					};
 				</script>
 			</html>
 		`,
-	};
+	}
 
-	w1, _ := window.Create(options)
+	w1, _ := window.Module.Create(options)
 
 	fmt.Println("[main] window", w1)
 
-	if (w1 == nil) {
+	if w1 == nil {
 		return
 	}
 
 	w1.SetTitle("Hello, Sailor!")
 	fmt.Println("[main] window position", w1.GetOuterPosition())
 
-	w2, _ := window.Create(options)
-	w2.SetTitle("YO!")
+	w2, _ := window.Module.Create(options)
+	window.Module.SetTitle(w2, "YO!")
+	window.Module.SetFullscreen(w2, true)
 
-	w2.SetFullscreen(true)
-
-	wasDestroyed := w2.Destroy()
+	wasDestroyed := window.Module.Destroy(w2)
 	fmt.Println("[main] wasDestroyed", wasDestroyed)
 
 	app.Run(tick)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require github.com/progrium/qtalk-go v0.5.0
 
 require (
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/rs/xid v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20210420210106-798c2154c571 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
+github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/progrium/qtalk-go v0.5.0 h1:4ZWIWQtDuYx/l89Jyf//xQWbomoctA/7mTkMj588gqI=
 github.com/progrium/qtalk-go v0.5.0/go.mod h1:vBfnZmpi9OTX/xNKQ6VOeq6uiaG3B4mhXI39K62bvn8=
 github.com/rs/xid v1.3.0 h1:6NjYksEUlhurdVehpc7S7dk6DAmcKv8V9gG0FsVN2U4=


### PR DESCRIPTION
This introduces a single test against the public RPC API. A dispatch mechanism is used until libhostbridge is thread-safe, and this is done at the RPC handler level since we also need to translate map to struct until qtalk better utilizes mapstructure. The window package code is re-organized towards code living in module methods so we can eventually just export the module to RPC. 

Also cleanup of Makefile to avoid rebuilding rust for ffi-debug, and gofmt has been run on touched files.