### PR TITLE
implement more Window_Options

### DIFF
--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -53,26 +53,23 @@ type Window struct {
 }
 
 type Options struct {
-	Transparent bool
+	AlwaysOnTop bool
 	Frameless   bool
+	Fullscreen  bool
+	Size        Size
+	MinSize     Size
+	MaxSize     Size
+	Maximized   bool
+	Position    Position
+	Resizable   bool
+	Title       string
+	Transparent bool
+	Visible     bool
+	Center      bool
+	Icon        []byte
+	URL         string
 	HTML        string
-
-	/*
-		AlwaysOnTop bool
-		Size        Size
-		MinSize     Size
-		MaxSize     Size
-		Maximized   bool
-		Position    Position
-		Resizable   bool
-		Title       string
-		Transparent bool
-		Visible     bool
-		Center      bool
-		Icon        string // bytestream callback
-		URL         string
-		Script      string
-	*/
+	Script      string
 }
 
 var EventLoop C.EventLoop
@@ -134,9 +131,27 @@ func Create(options Options) (*Window, error) {
 
 func (m *module) Create(options Options) (*Window, error) {
 	opts := C.Window_Options{
+		always_on_top: toCBool(options.AlwaysOnTop),
+		frameless:   toCBool(options.Frameless),
+		fullscreen: toCBool(options.Fullscreen),
+		size: C.Size{ width: C.double(options.Size.Width), height: C.double(options.Size.Height) },
+		min_size: C.Size{ width: C.double(options.MinSize.Width), height: C.double(options.MinSize.Height) },
+		max_size: C.Size{ width: C.double(options.MaxSize.Width), height: C.double(options.MaxSize.Height) },
+		maximized: toCBool(options.Maximized),
+		position: C.Position{ x: C.double(options.Position.X), y: C.double(options.Position.Y) },
+		resizable: toCBool(options.Resizable),
+		title: C.CString(options.Title),
 		transparent: toCBool(options.Transparent),
-		decorations: toCBool(!options.Frameless),
-		html:        C.CString(options.HTML),
+		visible: toCBool(options.Visible),
+		center: toCBool(options.Center),
+		icon: C.Icon{data: (*C.uchar)(nil), size: C.int(0)},
+		url: C.CString(options.URL),
+		html: C.CString(options.HTML),
+		script: C.CString(options.Script),
+	}
+
+	if len(options.Icon) > 0 {
+		opts.icon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&options.Icon[0])), size: C.int(len(options.Icon))}
 	}
 
 	appMenu := *(*C.Menu)(unsafe.Pointer(&menu.AppMenu))

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -140,9 +140,14 @@ func main() {
 	app.NewIndicator(iconData, trayTemplate)
 
 	options := window.Options{
+		Title: "Demo window",
 		// NOTE(nick): resizing a transparent window on MacOS seems really slow?
-		//Transparent: true,
+		Transparent: true,
 		Frameless: false,
+		Visible: true,
+		//Position: window.Position{X: 10, Y: 10},
+		//Size: window.Size{ Width: 360, Height: 240 },
+		//Center: true,
 		HTML: `
 			<!doctype html>
 			<html>

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -147,7 +147,7 @@ func main() {
 		Visible: true,
 		//Position: window.Position{X: 10, Y: 10},
 		//Size: window.Size{ Width: 360, Height: 240 },
-		//Center: true,
+		Center: true,
 		HTML: `
 			<!doctype html>
 			<html>

--- a/lib/hostbridge.h
+++ b/lib/hostbridge.h
@@ -68,10 +68,29 @@ typedef struct ContextMenu {
 	#endif
 } ContextMenu;
 
+typedef struct Icon {
+	unsigned char *data;
+	int size;
+} Icon;
+
 typedef struct Window_Options {
-	bool transparent;
-	bool decorations;
-	char *html;
+	bool     always_on_top;
+	bool     frameless;
+	bool     fullscreen;
+	Size     size;
+	Size     min_size;
+	Size     max_size;
+	bool     maximized;
+	Position position;
+	bool     resizable;
+	char *   title;
+	bool     transparent;
+	bool     visible;
+	bool     center;
+	Icon     icon;
+	char *   url;
+	char *   html;
+	char *   script;
 } Window_Options;
 
 typedef struct Menu_Item {
@@ -81,11 +100,6 @@ typedef struct Menu_Item {
 	bool selected;
 	char *accelerator;
 } Menu_Item;
-
-typedef struct Icon {
-	unsigned char *data;
-	int size;
-} Icon;
 
 typedef struct Display {
 	char *   name;

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -10,7 +10,7 @@ use wry::{
 	application::{
 		accelerator::{Accelerator},
 		clipboard::Clipboard,
-		dpi::{LogicalSize, LogicalPosition},
+		dpi::{LogicalSize, LogicalPosition, PhysicalPosition},
 		event::{Event, WindowEvent},
 		event_loop::{ControlFlow, EventLoop},
 		global_shortcut::ShortcutManager,
@@ -307,9 +307,7 @@ pub extern "C" fn window_create(event_loop: CEventLoop, options: CWindow_Options
 		window_builder = window_builder.with_max_inner_size(LogicalSize::new(options.max_size.width, options.max_size.height));
 	}
 
-	if options.center {
-		// @Incomplete: center window in default monitor
-	} else {
+	if !options.center {
 		window_builder = window_builder.with_position(LogicalPosition::new(options.position.x, options.position.y));
 	}
 
@@ -335,6 +333,17 @@ pub extern "C" fn window_create(event_loop: CEventLoop, options: CWindow_Options
 	}
 
 	let window = maybe_window.unwrap();
+
+	if options.center {
+		let monitor = window.current_monitor();
+
+		if let Some(monitor) = monitor {
+			let size = window.outer_size();
+			let monitor_size = monitor.size();
+			let center = PhysicalPosition::new((monitor_size.width - size.width) / 2, (monitor_size.height - size.height) / 2);
+			window.set_outer_position(center);
+		}
+	}
 
 	let webview_builder = WebViewBuilder::new(window);
 

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -16,7 +16,7 @@ use wry::{
 		global_shortcut::ShortcutManager,
 	  menu::{ContextMenu, MenuBar, MenuItemAttributes},
 	  system_tray::SystemTrayBuilder,
-		window::{WindowBuilder, Fullscreen},
+		window::{WindowBuilder, Fullscreen, Icon},
 	},
 	webview::{WebViewBuilder},
 };
@@ -73,9 +73,23 @@ type CContextMenu = ContextMenu;
 
 #[repr(C)]
 pub struct CWindow_Options {
-	pub transparent: CBool,
-	pub decorations: CBool,
-	pub html: CString,
+	pub always_on_top: CBool,
+	pub frameless:     CBool,
+	pub fullscreen:    CBool,
+	pub size:          CSize,
+	pub min_size:      CSize,
+	pub max_size:      CSize,
+	pub maximized:     CBool,
+	pub position:      CPosition,
+	pub resizable:     CBool,
+	pub title:         CString,
+	pub transparent:   CBool,
+	pub visible:       CBool,
+	pub center:        CBool,
+	pub icon:          CIcon,
+	pub url:           CString,
+	pub html:          CString,
+	pub script:        CString,
 }
 
 #[repr(C)]
@@ -267,14 +281,53 @@ pub extern "C" fn create_event_loop() -> CEventLoop {
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn window_create(event_loop: CEventLoop, options: CWindow_Options, menu: CMenu) -> i32 {
-	let maybe_window = WindowBuilder::new()
-		.with_title("")
+	let title = str_from_cstr(options.title);
+	let fullscreen = if options.fullscreen { Some(Fullscreen::Borderless(None)) } else { None };
+
+	let mut window_builder = WindowBuilder::new()
 		.with_menu(menu)
-		.with_decorations(options.decorations)
+		.with_always_on_top(options.always_on_top)
+		.with_decorations(!options.frameless)
+		.with_fullscreen(fullscreen)
+		.with_maximized(options.maximized)
+		.with_resizable(options.visible)
+		.with_title(title)
 		.with_transparent(options.transparent)
-		.build(&event_loop);
+		.with_visible(options.visible);
 
+	if options.size.width > 0.0 || options.size.height > 0.0 {
+		window_builder = window_builder.with_inner_size(LogicalSize::new(options.size.width, options.size.height));
+	}
 
+	if options.min_size.width > 0.0 || options.min_size.height > 0.0 {
+		window_builder = window_builder.with_min_inner_size(LogicalSize::new(options.min_size.width, options.min_size.height));
+	}
+
+	if options.max_size.width > 0.0 || options.max_size.height > 0.0 {
+		window_builder = window_builder.with_max_inner_size(LogicalSize::new(options.max_size.width, options.max_size.height));
+	}
+
+	if options.center {
+		// @Incomplete: center window in default monitor
+	} else {
+		window_builder = window_builder.with_position(LogicalPosition::new(options.position.x, options.position.y));
+	}
+
+	// @Incomplete: add support for icons
+	/*
+	if options.icon.size > 0 {
+		let icon = options.icon;
+		let icon_buf = unsafe { Vec::<u8>::from_raw_parts(icon.data, icon.size as usize, icon.size as usize) };
+
+		// @Incomplete: size is in pixels but we only have bytes here
+		let icon = Icon::from_rgba(icon_buf, 0, 0);
+		if let Ok(icon) = icon {
+			window_builder = window_builder.with_window_icon(Some(icon));
+		}
+	}
+	*/
+
+	let maybe_window = window_builder.build(&event_loop);
 	forget(event_loop);
 
 	if !maybe_window.is_ok() {
@@ -283,23 +336,45 @@ pub extern "C" fn window_create(event_loop: CEventLoop, options: CWindow_Options
 
 	let window = maybe_window.unwrap();
 
-	let maybe_webview_builder = WebViewBuilder::new(window);
+	let webview_builder = WebViewBuilder::new(window);
 
-	if !maybe_webview_builder.is_ok() {
+	if !webview_builder.is_ok() {
 		return -3;
 	}
 
+	let webview_builder = webview_builder.unwrap();
+
 	let html = string_from_cstr(options.html);
+	let url = str_from_cstr(options.url);
+	let script = str_from_cstr(options.script);
 
-	let maybe_webview = maybe_webview_builder.unwrap()
-		.with_transparent(options.transparent)
-		.with_html(html);
+	let mut webview_builder = webview_builder
+		.with_transparent(options.transparent);
 
-	if !maybe_webview.is_ok() {
-		return -4;
+	if script.len() > 0 {
+		webview_builder = webview_builder.with_initialization_script(script);
 	}
 
-	let result = maybe_webview.unwrap().build();
+	if url.len() > 0 {
+		let success = webview_builder.with_url(url);
+
+		if success.is_ok() {
+			webview_builder = success.unwrap();
+		} else {
+			return -4;
+		}
+	} else {
+		// From the wry docs: This will be ignored if url is already provided.
+		let success = webview_builder.with_html(html);
+
+		if success.is_ok() {
+			webview_builder = success.unwrap();
+		} else {
+			return -4;
+		}
+	}
+
+	let result = webview_builder.build();
 
 	if !result.is_ok() {
 		return -5;


### PR DESCRIPTION
not implemented: `Icon`

Icon is a bit tricker because it expects the Icon to be parsed already. So not sure if there's a built-in go thing for parsing images (most likely) or if we want the API from the Rust side to handle that