### PR TITLE
refactor bridge packages to export to rpc easily, started client

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -83,15 +83,22 @@ Object representing a window
 
 ```golang
 type Window struct {
+
+  // options or setters only
 	Title       string
-	Transparent bool
-	Size        Size
-	Position    Position
-	AlwaysOnTop bool
-	Fullscreen  bool
-	MinSize     Size
-	MaxSize     Size
 	Resizable   bool
+	AlwaysOnTop bool
+  MinSize     Size
+	MaxSize     Size
+  Visible     bool // user might be able to change?
+  Frameless   bool
+	
+  // options, setter, or user changeable
+  Maximized   bool      // pollable with is_maximized
+  Size        Size      // Resized event
+	Position    Position  // Moved event
+  Fullscreen  bool      // pollable with fullscreen
+  Focused     bool      // Focused event
 }
 ```
 

--- a/bridge/app/app.go
+++ b/bridge/app/app.go
@@ -39,22 +39,22 @@ func (mod module) SetMenu(m *menu.Menu) {
 }
 
 func NewIndicator(icon []byte, items []menu.Item) {
-	Module.NewIndicator(icon, items)
+	var cicon C.Icon
+	if len(icon) > 0 {
+		cicon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&icon[0])), size: C.int(len(icon))}
+	} else {
+		cicon = C.Icon{data: (*C.uchar)(nil), size: C.int(0)}
+	}
+
+	trayMenu := NewContextMenu(items)
+
+	eventLoop := *(*C.EventLoop)(core.EventLoop())
+	C.tray_set_system_tray(eventLoop, cicon, trayMenu)
 }
 
 func (m module) NewIndicator(icon []byte, items []menu.Item) {
 	core.Dispatch(func() {
-		var cicon C.Icon
-		if len(icon) > 0 {
-			cicon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&icon[0])), size: C.int(len(icon))}
-		} else {
-			cicon = C.Icon{data: (*C.uchar)(nil), size: C.int(0)}
-		}
-
-		trayMenu := NewContextMenu(items)
-
-		eventLoop := *(*C.EventLoop)(core.EventLoop())
-		C.tray_set_system_tray(eventLoop, cicon, trayMenu)
+		NewIndicator(icon, items)
 	})
 }
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,35 +1,36 @@
 package bridge
 
 import (
-	"unsafe"
-
 	"github.com/progrium/qtalk-go/codec"
 	"github.com/progrium/qtalk-go/fn"
 	"github.com/progrium/qtalk-go/rpc"
 
 	"github.com/progrium/hostbridge/bridge/app"
+	"github.com/progrium/hostbridge/bridge/core"
+	"github.com/progrium/hostbridge/bridge/menu"
+	"github.com/progrium/hostbridge/bridge/screen"
+	"github.com/progrium/hostbridge/bridge/shell"
 	"github.com/progrium/hostbridge/bridge/window"
 )
-
-type ret struct {
-	V interface{}
-	E error
-}
 
 func NewServer() *rpc.Server {
 	mux := rpc.NewRespondMux()
 
-	// most of this cruft can be eliminated when libhostbridge becomes thread-safe.
-	// ideal: mux.Handle("window", fn.HandlerFrom(window.Module))
-	mux.Handle("window.Create", fn.HandlerFrom(func(opts window.Options) (uintptr, error) {
-		rchan := make(chan ret)
-		app.Dispatch(func() {
-			w, err := window.Create(opts)
-			rchan <- ret{V: w, E: err}
-		})
-		r := <-rchan
-		return uintptr(unsafe.Pointer(r.V.(*window.Window))), r.E
+	mux.Handle("Listen", rpc.HandlerFunc(func(r rpc.Responder, c *rpc.Call) {
+		c.Receive(nil)
+		r.Continue(nil)
+		core.EventHandler = func(event core.Event) {
+			if event.Type > 0 {
+				r.Send(event)
+			}
+		}
 	}))
+
+	mux.Handle("window", fn.HandlerFrom(window.Module))
+	mux.Handle("menu", fn.HandlerFrom(menu.Module))
+	mux.Handle("app", fn.HandlerFrom(app.Module))
+	mux.Handle("screen", fn.HandlerFrom(screen.Module))
+	mux.Handle("shell", fn.HandlerFrom(shell.Module))
 
 	return &rpc.Server{
 		Codec:   codec.JSONCodec{},

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/progrium/hostbridge/bridge/app"
+	"github.com/progrium/hostbridge/bridge/core"
 	"github.com/progrium/hostbridge/bridge/window"
 	"github.com/progrium/qtalk-go/codec"
 	"github.com/progrium/qtalk-go/fn"
@@ -21,9 +21,9 @@ func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
 	go func() {
 		m.Run()
-		app.Quit()
+		core.Quit()
 	}()
-	app.Run(nil)
+	core.Run(nil)
 }
 
 func TestBridge(t *testing.T) {
@@ -53,7 +53,7 @@ func TestBridge(t *testing.T) {
 			</html>
 		`,
 	}
-	_, err = client.Call(context.Background(), "window.Create", fn.Args{opts}, nil)
+	_, err = client.Call(context.Background(), "window.New", fn.Args{opts}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bridge/core/dispatch.go
+++ b/bridge/core/dispatch.go
@@ -1,0 +1,13 @@
+package core
+
+var (
+	dispatchQueue chan func()
+)
+
+func init() {
+	dispatchQueue = make(chan func(), 1)
+}
+
+func Dispatch(fn func()) {
+	dispatchQueue <- fn
+}

--- a/bridge/core/events.go
+++ b/bridge/core/events.go
@@ -1,0 +1,30 @@
+package core
+
+var EventHandler func(event Event)
+
+type EventType int
+
+const (
+	EventNone EventType = iota
+	EventClose
+	EventDestroyed
+	EventFocused
+	EventResized
+	EventMoved
+	EventMenuItem
+	EventShortcut
+)
+
+func (e EventType) String() string {
+	return []string{"none", "close", "destroyed", "focused", "resized", "moved", "menu-item", "shortcut"}[e]
+}
+
+type Event struct {
+	Type     EventType
+	Name     string
+	WindowID Handle
+	Position Position
+	Size     Size
+	MenuID   uint16
+	Shortcut string
+}

--- a/bridge/core/loop.go
+++ b/bridge/core/loop.go
@@ -1,0 +1,69 @@
+package core
+
+/*
+#include "../../lib/hostbridge.h"
+*/
+import "C"
+
+import (
+	"os"
+	"unsafe"
+)
+
+var (
+	shouldQuit bool
+	eventLoop  C.EventLoop
+)
+
+func init() {
+	eventLoop = C.create_event_loop()
+}
+
+//export go_app_main_loop
+func go_app_main_loop(data C.Event) {
+	if shouldQuit {
+		return
+	}
+
+	select {
+	case fn := <-dispatchQueue:
+		fn()
+	default:
+	}
+
+	if EventHandler != nil {
+		event := Event{}
+		event.Type = EventType(data.event_type)
+		event.Name = event.Type.String()
+		event.WindowID = Handle(data.window_id)
+		event.Position = Position{X: float64(data.position.x), Y: float64(data.position.y)}
+		event.Size = Size{Width: float64(data.size.width), Height: float64(data.size.height)}
+		event.MenuID = uint16(data.menu_id)
+		event.Shortcut = C.GoString(data.shortcut)
+
+		EventHandler(event)
+	}
+}
+
+func EventLoop() unsafe.Pointer {
+	return unsafe.Pointer(&eventLoop)
+}
+
+func Run(handler func(event Event)) {
+	EventHandler = handler
+	eventLoop := *(*C.EventLoop)(EventLoop())
+	C.run(eventLoop, C.closure(C.go_app_main_loop))
+}
+
+func Quit() {
+	if !shouldQuit {
+		shouldQuit = true
+
+		os.Exit(0)
+
+		// @Incomplete: ideally this would return execution to the main thread
+		// but it seems fine because ControlFlow::Exit actually quits the whole process...
+		//
+		// @MemoryLeak: EventLoop destructor needs to be called here if we return execution to go main
+	}
+}

--- a/bridge/core/misc.go
+++ b/bridge/core/misc.go
@@ -1,0 +1,15 @@
+package core
+
+import "C"
+
+type Position struct {
+	X float64
+	Y float64
+}
+
+type Size struct {
+	Width  float64
+	Height float64
+}
+
+type Handle int

--- a/bridge/menu/menu.go
+++ b/bridge/menu/menu.go
@@ -41,8 +41,6 @@ func New(items []Item) *Menu {
 }
 
 func (m module) New(items []Item) *Menu {
-	// ret := make(chan *Menu)
-	// core.Dispatch(func() {
 	cmenu := C.menu_create()
 
 	for _, it := range items {
@@ -58,9 +56,6 @@ func (m module) New(items []Item) *Menu {
 	menu.Handle = cmenu
 
 	return menu
-	// 	ret <- menu
-	// })
-	// return <-ret
 }
 
 func buildCMenuItem(item Item) C.Menu_Item {

--- a/bridge/menu/menu.go
+++ b/bridge/menu/menu.go
@@ -5,7 +5,13 @@ package menu
 */
 import "C"
 
-type Handle int
+var Module *module
+
+func init() {
+	Module = &module{}
+}
+
+type module struct{}
 
 type Menu struct {
 	/*
@@ -30,30 +36,31 @@ type Item struct {
 	SubMenu []Item
 }
 
-var AppMenu Menu
-var AppMenuWasSet bool
-
-func init() {
-	AppMenu = New([]Item{})
-	AppMenuWasSet = false
+func New(items []Item) *Menu {
+	return Module.New(items)
 }
 
-func New(items []Item) Menu {
-	menu := C.menu_create()
+func (m module) New(items []Item) *Menu {
+	// ret := make(chan *Menu)
+	// core.Dispatch(func() {
+	cmenu := C.menu_create()
 
 	for _, it := range items {
 		if len(it.SubMenu) > 0 {
-			submenu := New(it.SubMenu)
-			C.menu_add_submenu(menu, C.CString(it.Title), toCBool(it.Enabled), submenu.Handle)
+			submenu := m.New(it.SubMenu)
+			C.menu_add_submenu(cmenu, C.CString(it.Title), toCBool(it.Enabled), submenu.Handle)
 		} else {
-			C.menu_add_item(menu, buildCMenuItem(it))
+			C.menu_add_item(cmenu, buildCMenuItem(it))
 		}
 	}
 
-	result := Menu{}
-	result.Handle = menu
+	menu := &Menu{}
+	menu.Handle = cmenu
 
-	return result
+	return menu
+	// 	ret <- menu
+	// })
+	// return <-ret
 }
 
 func buildCMenuItem(item Item) C.Menu_Item {
@@ -72,8 +79,4 @@ func toCBool(it bool) C.uchar {
 	}
 
 	return C.uchar(0)
-}
-
-func toBool(it C.uchar) bool {
-	return int(it) != 0
 }

--- a/bridge/screen/screen.go
+++ b/bridge/screen/screen.go
@@ -37,31 +37,31 @@ type Size struct {
 }
 
 func Displays() []Display {
-	return Module.Displays()
+	array := C.screen_get_available_displays()
+
+	n := int(array.count)
+	result := make([]Display, n)
+
+	items := (*[1 << 28]C.Display)(unsafe.Pointer(array.data))[:n:n]
+
+	for i := 0; i < n; i++ {
+		display := items[i]
+
+		result[i] = Display{
+			Name:        C.GoString(display.name),
+			Size:        Size{Width: float64(display.size.width), Height: float64(display.size.height)},
+			Position:    Position{X: float64(display.position.x), Y: float64(display.position.y)},
+			ScaleFactor: float64(display.scale_factor),
+		}
+	}
+
+	return result
 }
 
 func (m module) Displays() []Display {
 	ret := make(chan []Display)
 	core.Dispatch(func() {
-		array := C.screen_get_available_displays()
-
-		n := int(array.count)
-		result := make([]Display, n)
-
-		items := (*[1 << 28]C.Display)(unsafe.Pointer(array.data))[:n:n]
-
-		for i := 0; i < n; i++ {
-			display := items[i]
-
-			result[i] = Display{
-				Name:        C.GoString(display.name),
-				Size:        Size{Width: float64(display.size.width), Height: float64(display.size.height)},
-				Position:    Position{X: float64(display.position.x), Y: float64(display.position.y)},
-				ScaleFactor: float64(display.scale_factor),
-			}
-		}
-
-		ret <- result
+		ret <- Displays()
 	})
 	return <-ret
 }

--- a/bridge/screen/screen.go
+++ b/bridge/screen/screen.go
@@ -7,7 +7,17 @@ import "C"
 
 import (
 	"unsafe"
+
+	"github.com/progrium/hostbridge/bridge/core"
 )
+
+var Module *module
+
+func init() {
+	Module = &module{}
+}
+
+type module struct{}
 
 type Display struct {
 	Name        string
@@ -27,23 +37,31 @@ type Size struct {
 }
 
 func Displays() []Display {
-	array := C.screen_get_available_displays()
+	return Module.Displays()
+}
 
-	n := int(array.count)
-	result := make([]Display, n)
+func (m module) Displays() []Display {
+	ret := make(chan []Display)
+	core.Dispatch(func() {
+		array := C.screen_get_available_displays()
 
-	items := (*[1 << 28]C.Display)(unsafe.Pointer(array.data))[:n:n]
+		n := int(array.count)
+		result := make([]Display, n)
 
-	for i := 0; i < n; i++ {
-		display := items[i]
+		items := (*[1 << 28]C.Display)(unsafe.Pointer(array.data))[:n:n]
 
-		result[i] = Display{
-			Name:        C.GoString(display.name),
-			Size:        Size{Width: float64(display.size.width), Height: float64(display.size.height)},
-			Position:    Position{X: float64(display.position.x), Y: float64(display.position.y)},
-			ScaleFactor: float64(display.scale_factor),
+		for i := 0; i < n; i++ {
+			display := items[i]
+
+			result[i] = Display{
+				Name:        C.GoString(display.name),
+				Size:        Size{Width: float64(display.size.width), Height: float64(display.size.height)},
+				Position:    Position{X: float64(display.position.x), Y: float64(display.position.y)},
+				ScaleFactor: float64(display.scale_factor),
+			}
 		}
-	}
 
-	return result
+		ret <- result
+	})
+	return <-ret
 }

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -120,57 +120,54 @@ func (m *module) FindByID(windowID core.Handle) *Window {
 }
 
 func New(options Options) (*Window, error) {
-	return Module.New(options)
+	opts := C.Window_Options{
+		always_on_top: toCBool(options.AlwaysOnTop),
+		frameless:     toCBool(options.Frameless),
+		fullscreen:    toCBool(options.Fullscreen),
+		size:          C.Size{width: C.double(options.Size.Width), height: C.double(options.Size.Height)},
+		min_size:      C.Size{width: C.double(options.MinSize.Width), height: C.double(options.MinSize.Height)},
+		max_size:      C.Size{width: C.double(options.MaxSize.Width), height: C.double(options.MaxSize.Height)},
+		maximized:     toCBool(options.Maximized),
+		position:      C.Position{x: C.double(options.Position.X), y: C.double(options.Position.Y)},
+		resizable:     toCBool(options.Resizable),
+		title:         C.CString(options.Title),
+		transparent:   toCBool(options.Transparent),
+		visible:       toCBool(options.Visible),
+		center:        toCBool(options.Center),
+		icon:          C.Icon{data: (*C.uchar)(nil), size: C.int(0)},
+		url:           C.CString(options.URL),
+		html:          C.CString(options.HTML),
+		script:        C.CString(options.Script),
+	}
+
+	if len(options.Icon) > 0 {
+		opts.icon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&options.Icon[0])), size: C.int(len(options.Icon))}
+	}
+
+	appMenu := *(*C.Menu)(unsafe.Pointer(app.Module.Menu()))
+	eventLoop := *(*C.EventLoop)(core.EventLoop())
+	result := C.window_create(eventLoop, opts, appMenu)
+	id := int(result)
+
+	window := Window{}
+	window.ID = core.Handle(id)
+	window.Transparent = options.Transparent
+
+	if id >= 0 {
+		Module.mu.Lock()
+		Module.windows = append(Module.windows, window)
+		Module.mu.Unlock()
+		return &window, nil
+	}
+
+	return nil, errors.New("Failed to create window")
 }
 
 func (m *module) New(options Options) (*Window, error) {
 	ret := make(chan retVal)
 	core.Dispatch(func() {
-
-		opts := C.Window_Options{
-			always_on_top: toCBool(options.AlwaysOnTop),
-			frameless:     toCBool(options.Frameless),
-			fullscreen:    toCBool(options.Fullscreen),
-			size:          C.Size{width: C.double(options.Size.Width), height: C.double(options.Size.Height)},
-			min_size:      C.Size{width: C.double(options.MinSize.Width), height: C.double(options.MinSize.Height)},
-			max_size:      C.Size{width: C.double(options.MaxSize.Width), height: C.double(options.MaxSize.Height)},
-			maximized:     toCBool(options.Maximized),
-			position:      C.Position{x: C.double(options.Position.X), y: C.double(options.Position.Y)},
-			resizable:     toCBool(options.Resizable),
-			title:         C.CString(options.Title),
-			transparent:   toCBool(options.Transparent),
-			visible:       toCBool(options.Visible),
-			center:        toCBool(options.Center),
-			icon:          C.Icon{data: (*C.uchar)(nil), size: C.int(0)},
-			url:           C.CString(options.URL),
-			html:          C.CString(options.HTML),
-			script:        C.CString(options.Script),
-		}
-
-		if len(options.Icon) > 0 {
-			opts.icon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&options.Icon[0])), size: C.int(len(options.Icon))}
-		}
-
-		appMenu := *(*C.Menu)(unsafe.Pointer(app.Module.Menu()))
-		eventLoop := *(*C.EventLoop)(core.EventLoop())
-		result := C.window_create(eventLoop, opts, appMenu)
-		id := int(result)
-
-		window := Window{}
-		window.ID = core.Handle(id)
-		window.Transparent = options.Transparent
-
-		if id >= 0 {
-			m.mu.Lock()
-			m.windows = append(m.windows, window)
-			m.mu.Unlock()
-			ret <- retVal{&window, nil}
-			return
-		}
-
-		ret <- retVal{nil, errors.New("Failed to create window")}
-		return
-
+		w, err := New(options)
+		ret <- retVal{w, err}
 	})
 	r := <-ret
 	return r.V.(*Window), r.E
@@ -181,7 +178,11 @@ func (m *module) Destroy(h core.Handle) (bool, error) {
 	if w == nil {
 		return false, ErrBadHandle
 	}
-	return w.Destroy(), nil
+	ret := make(chan bool)
+	core.Dispatch(func() {
+		ret <- w.Destroy()
+	})
+	return <-ret, nil
 }
 
 func (w *Window) Destroy() bool {
@@ -190,23 +191,19 @@ func (w *Window) Destroy() bool {
 	if w.destroyed {
 		return false
 	}
-	ret := make(chan bool)
-	core.Dispatch(func() {
-		success := C.window_destroy(C.int(w.ID))
-		if !fromCBool(success) {
-			ret <- false
-			return
-		}
-		w.destroyed = true
-		index := Module.FindIndexByID(w.ID)
-		if index >= 0 {
-			Module.mu.Lock()
-			Module.windows = append(Module.windows[:index], Module.windows[index+1:]...)
-			Module.mu.Unlock()
-		}
-		ret <- true
-	})
-	return <-ret
+
+	success := C.window_destroy(C.int(w.ID))
+	if !fromCBool(success) {
+		return false
+	}
+	w.destroyed = true
+	index := Module.FindIndexByID(w.ID)
+	if index >= 0 {
+		Module.mu.Lock()
+		Module.windows = append(Module.windows[:index], Module.windows[index+1:]...)
+		Module.mu.Unlock()
+	}
+	return true
 }
 
 func (m *module) IsDestroyed(h core.Handle) (bool, error) {
@@ -228,14 +225,14 @@ func (m *module) Focus(h core.Handle) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.Focus()
+	core.Dispatch(func() {
+		w.Focus()
+	})
 	return nil
 }
 
 func (w *Window) Focus() {
-	core.Dispatch(func() {
-		C.window_set_focused(C.int(w.ID))
-	})
+	C.window_set_focused(C.int(w.ID))
 }
 
 func (m *module) SetVisible(h core.Handle, visible bool) error {
@@ -243,14 +240,14 @@ func (m *module) SetVisible(h core.Handle, visible bool) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetVisible(visible)
+	core.Dispatch(func() {
+		w.SetVisible(visible)
+	})
 	return nil
 }
 
 func (it *Window) SetVisible(visible bool) {
-	core.Dispatch(func() {
-		C.window_set_visible(C.int(it.ID), toCBool(visible))
-	})
+	C.window_set_visible(C.int(it.ID), toCBool(visible))
 }
 
 func (m *module) IsVisible(h core.Handle) (bool, error) {
@@ -258,15 +255,15 @@ func (m *module) IsVisible(h core.Handle) (bool, error) {
 	if w == nil {
 		return false, ErrBadHandle
 	}
-	return w.IsVisible(), nil
+	ret := make(chan bool)
+	core.Dispatch(func() {
+		ret <- w.IsVisible()
+	})
+	return <-ret, nil
 }
 
 func (w *Window) IsVisible() bool {
-	ret := make(chan bool)
-	core.Dispatch(func() {
-		ret <- fromCBool(C.window_is_visible(C.int(w.ID)))
-	})
-	return <-ret
+	return fromCBool(C.window_is_visible(C.int(w.ID)))
 }
 
 func (m *module) SetMaximized(h core.Handle, maximized bool) error {
@@ -274,14 +271,14 @@ func (m *module) SetMaximized(h core.Handle, maximized bool) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetMaximized(maximized)
+	core.Dispatch(func() {
+		w.SetMaximized(maximized)
+	})
 	return nil
 }
 
 func (w *Window) SetMaximized(maximized bool) {
-	core.Dispatch(func() {
-		C.window_set_maximized(C.int(w.ID), toCBool(maximized))
-	})
+	C.window_set_maximized(C.int(w.ID), toCBool(maximized))
 }
 
 func (m *module) SetMinimized(h core.Handle, minimized bool) error {
@@ -289,14 +286,14 @@ func (m *module) SetMinimized(h core.Handle, minimized bool) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetMinimized(minimized)
+	core.Dispatch(func() {
+		w.SetMinimized(minimized)
+	})
 	return nil
 }
 
 func (w *Window) SetMinimized(minimized bool) {
-	core.Dispatch(func() {
-		C.window_set_minimized(C.int(w.ID), toCBool(minimized))
-	})
+	C.window_set_minimized(C.int(w.ID), toCBool(minimized))
 }
 
 func (m *module) SetFullscreen(h core.Handle, fullscreen bool) error {
@@ -304,14 +301,14 @@ func (m *module) SetFullscreen(h core.Handle, fullscreen bool) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetFullscreen(fullscreen)
+	core.Dispatch(func() {
+		w.SetFullscreen(fullscreen)
+	})
 	return nil
 }
 
 func (w *Window) SetFullscreen(fullscreen bool) {
-	core.Dispatch(func() {
-		C.window_set_fullscreen(C.int(w.ID), toCBool(fullscreen))
-	})
+	C.window_set_fullscreen(C.int(w.ID), toCBool(fullscreen))
 }
 
 func (m *module) SetSize(h core.Handle, size core.Size) error {
@@ -319,15 +316,15 @@ func (m *module) SetSize(h core.Handle, size core.Size) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetSize(size)
+	core.Dispatch(func() {
+		w.SetSize(size)
+	})
 	return nil
 }
 
 func (w *Window) SetSize(size core.Size) {
-	core.Dispatch(func() {
-		arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
-		C.window_set_size(C.int(w.ID), arg)
-	})
+	arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
+	C.window_set_size(C.int(w.ID), arg)
 }
 
 func (m *module) SetMinSize(h core.Handle, size core.Size) error {
@@ -335,15 +332,15 @@ func (m *module) SetMinSize(h core.Handle, size core.Size) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetMinSize(size)
+	core.Dispatch(func() {
+		w.SetMinSize(size)
+	})
 	return nil
 }
 
 func (w *Window) SetMinSize(size core.Size) {
-	core.Dispatch(func() {
-		arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
-		C.window_set_min_size(C.int(w.ID), arg)
-	})
+	arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
+	C.window_set_min_size(C.int(w.ID), arg)
 }
 
 func (m *module) SetMaxSize(h core.Handle, size core.Size) error {
@@ -351,15 +348,15 @@ func (m *module) SetMaxSize(h core.Handle, size core.Size) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetMaxSize(size)
+	core.Dispatch(func() {
+		w.SetMaxSize(size)
+	})
 	return nil
 }
 
 func (w *Window) SetMaxSize(size core.Size) {
-	core.Dispatch(func() {
-		arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
-		C.window_set_max_size(C.int(w.ID), arg)
-	})
+	arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
+	C.window_set_max_size(C.int(w.ID), arg)
 }
 
 func (m *module) SetResizable(h core.Handle, resizable bool) error {
@@ -367,14 +364,14 @@ func (m *module) SetResizable(h core.Handle, resizable bool) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetResizable(resizable)
+	core.Dispatch(func() {
+		w.SetResizable(resizable)
+	})
 	return nil
 }
 
 func (w *Window) SetResizable(resizable bool) {
-	core.Dispatch(func() {
-		C.window_set_resizable(C.int(w.ID), toCBool(resizable))
-	})
+	C.window_set_resizable(C.int(w.ID), toCBool(resizable))
 }
 
 func (m *module) SetAlwaysOnTop(h core.Handle, always bool) error {
@@ -382,14 +379,14 @@ func (m *module) SetAlwaysOnTop(h core.Handle, always bool) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetAlwaysOnTop(always)
+	core.Dispatch(func() {
+		w.SetAlwaysOnTop(always)
+	})
 	return nil
 }
 
 func (w *Window) SetAlwaysOnTop(always bool) {
-	core.Dispatch(func() {
-		C.window_set_always_on_top(C.int(w.ID), toCBool(always))
-	})
+	C.window_set_always_on_top(C.int(w.ID), toCBool(always))
 }
 
 func (m *module) SetPosition(h core.Handle, position core.Position) error {
@@ -397,15 +394,15 @@ func (m *module) SetPosition(h core.Handle, position core.Position) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetPosition(position)
+	core.Dispatch(func() {
+		w.SetPosition(position)
+	})
 	return nil
 }
 
 func (w *Window) SetPosition(position core.Position) {
-	core.Dispatch(func() {
-		arg := C.Position{x: C.double(position.X), y: C.double(position.Y)}
-		C.window_set_position(C.int(w.ID), arg)
-	})
+	arg := C.Position{x: C.double(position.X), y: C.double(position.Y)}
+	C.window_set_position(C.int(w.ID), arg)
 }
 
 func (m *module) SetTitle(h core.Handle, title string) error {
@@ -413,16 +410,14 @@ func (m *module) SetTitle(h core.Handle, title string) error {
 	if w == nil {
 		return ErrBadHandle
 	}
-	w.SetTitle(title)
+	core.Dispatch(func() {
+		w.SetTitle(title)
+	})
 	return nil
 }
 
 func (w *Window) SetTitle(title string) {
-	ret := make(chan bool)
-	core.Dispatch(func() {
-		ret <- fromCBool(C.window_set_title(C.int(w.ID), C.CString(title)))
-	})
-	if <-ret {
+	if fromCBool(C.window_set_title(C.int(w.ID), C.CString(title))) {
 		w.Title = title
 	}
 }
@@ -432,16 +427,16 @@ func (m *module) GetOuterPosition(h core.Handle) (core.Position, error) {
 	if w == nil {
 		return core.Position{}, ErrBadHandle
 	}
-	return w.GetOuterPosition(), nil
+	ret := make(chan core.Position)
+	core.Dispatch(func() {
+		ret <- w.GetOuterPosition()
+	})
+	return <-ret, nil
 }
 
 func (w *Window) GetOuterPosition() core.Position {
-	ret := make(chan core.Position)
-	core.Dispatch(func() {
-		result := C.window_get_outer_position(C.int(w.ID))
-		ret <- core.Position{X: float64(result.x), Y: float64(result.y)}
-	})
-	return <-ret
+	result := C.window_get_outer_position(C.int(w.ID))
+	return core.Position{X: float64(result.x), Y: float64(result.y)}
 }
 
 func (m *module) GetOuterSize(h core.Handle) (core.Size, error) {
@@ -449,16 +444,16 @@ func (m *module) GetOuterSize(h core.Handle) (core.Size, error) {
 	if w == nil {
 		return core.Size{}, ErrBadHandle
 	}
-	return w.GetOuterSize(), nil
+	ret := make(chan core.Size)
+	core.Dispatch(func() {
+		ret <- w.GetOuterSize()
+	})
+	return <-ret, nil
 }
 
 func (w *Window) GetOuterSize() core.Size {
-	ret := make(chan core.Size)
-	core.Dispatch(func() {
-		result := C.window_get_outer_size(C.int(w.ID))
-		ret <- core.Size{Width: float64(result.width), Height: float64(result.height)}
-	})
-	return <-ret
+	result := C.window_get_outer_size(C.int(w.ID))
+	return core.Size{Width: float64(result.width), Height: float64(result.height)}
 }
 
 func toCBool(it bool) C.uchar {

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -12,8 +12,18 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/progrium/hostbridge/bridge/menu"
+	"github.com/progrium/hostbridge/bridge/app"
+	"github.com/progrium/hostbridge/bridge/core"
 )
+
+var (
+	Module       *module
+	ErrBadHandle = errors.New("bad handle")
+)
+
+func init() {
+	Module = &module{}
+}
 
 type module struct {
 	mu sync.Mutex
@@ -22,45 +32,39 @@ type module struct {
 	shouldQuit bool
 }
 
-type Position struct {
-	X float64
-	Y float64
+type retVal struct {
+	V interface{}
+	E error
 }
-
-type Size struct {
-	Width  float64
-	Height float64
-}
-
-type Handle int
 
 type Window struct {
-	ID          Handle
+	ID          core.Handle
 	Title       string
 	Transparent bool
 
 	/*
-		Size        Size
-		Position    Position
+		Size        core.Size
+		Position    core.Position
 		AlwaysOnTop bool
 		Fullscreen  bool
-		MinSize     Size
-		MaxSize     Size
+		MinSize     core.Size
+		MaxSize     core.Size
 		Resizable   bool
 	*/
 
 	destroyed bool
+	mu        sync.Mutex
 }
 
 type Options struct {
 	AlwaysOnTop bool
 	Frameless   bool
 	Fullscreen  bool
-	Size        Size
-	MinSize     Size
-	MaxSize     Size
+	Size        core.Size
+	MinSize     core.Size
+	MaxSize     core.Size
 	Maximized   bool
-	Position    Position
+	Position    core.Position
 	Resizable   bool
 	Title       string
 	Transparent bool
@@ -72,23 +76,13 @@ type Options struct {
 	Script      string
 }
 
-var EventLoop C.EventLoop
-var Module *module
-
-func init() {
-	EventLoop = C.create_event_loop()
-	Module = &module{}
-}
-
 func All() (result []Window) {
 	return Module.All()
 }
 
 func (m *module) All() (result []Window) {
-	/*
-		module.mu.Lock()
-		defer module.mu.Unlock()
-	*/
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	for _, it := range m.windows {
 		if !it.destroyed {
@@ -99,11 +93,9 @@ func (m *module) All() (result []Window) {
 	return result
 }
 
-func (m *module) FindIndexByID(windowID Handle) int {
-	/*
-		module.mu.Lock()
-		defer module.mu.Unlock()
-	*/
+func (m *module) FindIndexByID(windowID core.Handle) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	var result int = -1
 
@@ -117,218 +109,356 @@ func (m *module) FindIndexByID(windowID Handle) int {
 	return result
 }
 
-func (m *module) FindByID(windowID Handle) *Window {
+func (m *module) FindByID(windowID core.Handle) *Window {
 	index := m.FindIndexByID(windowID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if index >= 0 {
 		return &m.windows[index]
 	}
 	return nil
 }
 
-func Create(options Options) (*Window, error) {
-	return Module.Create(options)
+func New(options Options) (*Window, error) {
+	return Module.New(options)
 }
 
-func (m *module) Create(options Options) (*Window, error) {
-	opts := C.Window_Options{
-		always_on_top: toCBool(options.AlwaysOnTop),
-		frameless:   toCBool(options.Frameless),
-		fullscreen: toCBool(options.Fullscreen),
-		size: C.Size{ width: C.double(options.Size.Width), height: C.double(options.Size.Height) },
-		min_size: C.Size{ width: C.double(options.MinSize.Width), height: C.double(options.MinSize.Height) },
-		max_size: C.Size{ width: C.double(options.MaxSize.Width), height: C.double(options.MaxSize.Height) },
-		maximized: toCBool(options.Maximized),
-		position: C.Position{ x: C.double(options.Position.X), y: C.double(options.Position.Y) },
-		resizable: toCBool(options.Resizable),
-		title: C.CString(options.Title),
-		transparent: toCBool(options.Transparent),
-		visible: toCBool(options.Visible),
-		center: toCBool(options.Center),
-		icon: C.Icon{data: (*C.uchar)(nil), size: C.int(0)},
-		url: C.CString(options.URL),
-		html: C.CString(options.HTML),
-		script: C.CString(options.Script),
-	}
+func (m *module) New(options Options) (*Window, error) {
+	ret := make(chan retVal)
+	core.Dispatch(func() {
 
-	if len(options.Icon) > 0 {
-		opts.icon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&options.Icon[0])), size: C.int(len(options.Icon))}
-	}
-
-	appMenu := *(*C.Menu)(unsafe.Pointer(&menu.AppMenu))
-	result := C.window_create(EventLoop, opts, appMenu)
-	id := int(result)
-
-	window := Window{}
-	window.ID = Handle(id)
-	window.Transparent = options.Transparent
-
-	if id >= 0 {
-		m.windows = append(m.windows, window)
-		return &window, nil
-	}
-
-	return nil, errors.New("Failed to create window")
-}
-
-func (m *module) Destroy(w *Window) bool {
-	return w.Destroy()
-}
-
-func (it *Window) Destroy() bool {
-	result := false
-
-	if !it.destroyed {
-		success := C.window_destroy(C.int(it.ID))
-		if toBool(success) {
-			it.destroyed = true
-			result = true
-
-			index := Module.FindIndexByID(it.ID)
-			if index >= 0 {
-				Module.windows = append(Module.windows[:index], Module.windows[index+1:]...)
-			}
+		opts := C.Window_Options{
+			always_on_top: toCBool(options.AlwaysOnTop),
+			frameless:     toCBool(options.Frameless),
+			fullscreen:    toCBool(options.Fullscreen),
+			size:          C.Size{width: C.double(options.Size.Width), height: C.double(options.Size.Height)},
+			min_size:      C.Size{width: C.double(options.MinSize.Width), height: C.double(options.MinSize.Height)},
+			max_size:      C.Size{width: C.double(options.MaxSize.Width), height: C.double(options.MaxSize.Height)},
+			maximized:     toCBool(options.Maximized),
+			position:      C.Position{x: C.double(options.Position.X), y: C.double(options.Position.Y)},
+			resizable:     toCBool(options.Resizable),
+			title:         C.CString(options.Title),
+			transparent:   toCBool(options.Transparent),
+			visible:       toCBool(options.Visible),
+			center:        toCBool(options.Center),
+			icon:          C.Icon{data: (*C.uchar)(nil), size: C.int(0)},
+			url:           C.CString(options.URL),
+			html:          C.CString(options.HTML),
+			script:        C.CString(options.Script),
 		}
+
+		if len(options.Icon) > 0 {
+			opts.icon = C.Icon{data: (*C.uchar)(unsafe.Pointer(&options.Icon[0])), size: C.int(len(options.Icon))}
+		}
+
+		appMenu := *(*C.Menu)(unsafe.Pointer(app.Module.Menu()))
+		eventLoop := *(*C.EventLoop)(core.EventLoop())
+		result := C.window_create(eventLoop, opts, appMenu)
+		id := int(result)
+
+		window := Window{}
+		window.ID = core.Handle(id)
+		window.Transparent = options.Transparent
+
+		if id >= 0 {
+			m.mu.Lock()
+			m.windows = append(m.windows, window)
+			m.mu.Unlock()
+			ret <- retVal{&window, nil}
+			return
+		}
+
+		ret <- retVal{nil, errors.New("Failed to create window")}
+		return
+
+	})
+	r := <-ret
+	return r.V.(*Window), r.E
+}
+
+func (m *module) Destroy(h core.Handle) (bool, error) {
+	w := m.FindByID(h)
+	if w == nil {
+		return false, ErrBadHandle
 	}
-
-	return result
+	return w.Destroy(), nil
 }
 
-func (m *module) IsDestroyed(w *Window) bool {
-	return w.IsDestroyed()
+func (w *Window) Destroy() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.destroyed {
+		return false
+	}
+	ret := make(chan bool)
+	core.Dispatch(func() {
+		success := C.window_destroy(C.int(w.ID))
+		if !fromCBool(success) {
+			ret <- false
+			return
+		}
+		w.destroyed = true
+		index := Module.FindIndexByID(w.ID)
+		if index >= 0 {
+			Module.mu.Lock()
+			Module.windows = append(Module.windows[:index], Module.windows[index+1:]...)
+			Module.mu.Unlock()
+		}
+		ret <- true
+	})
+	return <-ret
 }
 
-func (it *Window) IsDestroyed() bool {
-	return it.destroyed
+func (m *module) IsDestroyed(h core.Handle) (bool, error) {
+	w := m.FindByID(h)
+	if w == nil {
+		return false, ErrBadHandle
+	}
+	return w.IsDestroyed(), nil
 }
 
-func (m *module) Focus(w *Window) {
+func (w *Window) IsDestroyed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.destroyed
+}
+
+func (m *module) Focus(h core.Handle) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.Focus()
+	return nil
 }
 
-func (it *Window) Focus() {
-	C.window_set_focused(C.int(it.ID))
+func (w *Window) Focus() {
+	core.Dispatch(func() {
+		C.window_set_focused(C.int(w.ID))
+	})
 }
 
-func (m *module) SetVisible(w *Window, visible bool) {
+func (m *module) SetVisible(h core.Handle, visible bool) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetVisible(visible)
+	return nil
 }
 
 func (it *Window) SetVisible(visible bool) {
-	C.window_set_visible(C.int(it.ID), toCBool(visible))
+	core.Dispatch(func() {
+		C.window_set_visible(C.int(it.ID), toCBool(visible))
+	})
 }
 
-func (m *module) IsVisible(w *Window) bool {
-	return w.IsVisible()
+func (m *module) IsVisible(h core.Handle) (bool, error) {
+	w := m.FindByID(h)
+	if w == nil {
+		return false, ErrBadHandle
+	}
+	return w.IsVisible(), nil
 }
 
-func (it *Window) IsVisible() bool {
-	result := C.window_is_visible(C.int(it.ID))
-	return toBool(result)
+func (w *Window) IsVisible() bool {
+	ret := make(chan bool)
+	core.Dispatch(func() {
+		ret <- fromCBool(C.window_is_visible(C.int(w.ID)))
+	})
+	return <-ret
 }
 
-func (m *module) SetMaximized(w *Window, maximized bool) {
+func (m *module) SetMaximized(h core.Handle, maximized bool) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetMaximized(maximized)
+	return nil
 }
 
-func (it *Window) SetMaximized(maximized bool) {
-	C.window_set_maximized(C.int(it.ID), toCBool(maximized))
+func (w *Window) SetMaximized(maximized bool) {
+	core.Dispatch(func() {
+		C.window_set_maximized(C.int(w.ID), toCBool(maximized))
+	})
 }
 
-func (m *module) SetMinimized(w *Window, minimized bool) {
+func (m *module) SetMinimized(h core.Handle, minimized bool) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetMinimized(minimized)
+	return nil
 }
 
-func (it *Window) SetMinimized(minimized bool) {
-	C.window_set_minimized(C.int(it.ID), toCBool(minimized))
+func (w *Window) SetMinimized(minimized bool) {
+	core.Dispatch(func() {
+		C.window_set_minimized(C.int(w.ID), toCBool(minimized))
+	})
 }
 
-func (m *module) SetFullscreen(w *Window, fullscreen bool) {
+func (m *module) SetFullscreen(h core.Handle, fullscreen bool) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetFullscreen(fullscreen)
+	return nil
 }
 
-func (it *Window) SetFullscreen(fullscreen bool) {
-	C.window_set_fullscreen(C.int(it.ID), toCBool(fullscreen))
+func (w *Window) SetFullscreen(fullscreen bool) {
+	core.Dispatch(func() {
+		C.window_set_fullscreen(C.int(w.ID), toCBool(fullscreen))
+	})
 }
 
-func (m *module) SetSize(w *Window, size Size) {
+func (m *module) SetSize(h core.Handle, size core.Size) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetSize(size)
+	return nil
 }
 
-func (it *Window) SetSize(size Size) {
-	arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
-	C.window_set_size(C.int(it.ID), arg)
+func (w *Window) SetSize(size core.Size) {
+	core.Dispatch(func() {
+		arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
+		C.window_set_size(C.int(w.ID), arg)
+	})
 }
 
-func (m *module) SetMinSize(w *Window, size Size) {
+func (m *module) SetMinSize(h core.Handle, size core.Size) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetMinSize(size)
+	return nil
 }
 
-func (it *Window) SetMinSize(size Size) {
-	arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
-	C.window_set_min_size(C.int(it.ID), arg)
+func (w *Window) SetMinSize(size core.Size) {
+	core.Dispatch(func() {
+		arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
+		C.window_set_min_size(C.int(w.ID), arg)
+	})
 }
 
-func (m *module) SetMaxSize(w *Window, size Size) {
+func (m *module) SetMaxSize(h core.Handle, size core.Size) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetMaxSize(size)
+	return nil
 }
 
-func (it *Window) SetMaxSize(size Size) {
-	arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
-	C.window_set_max_size(C.int(it.ID), arg)
+func (w *Window) SetMaxSize(size core.Size) {
+	core.Dispatch(func() {
+		arg := C.Size{width: C.double(size.Width), height: C.double(size.Height)}
+		C.window_set_max_size(C.int(w.ID), arg)
+	})
 }
 
-func (m *module) SetResizable(w *Window, resizable bool) {
+func (m *module) SetResizable(h core.Handle, resizable bool) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetResizable(resizable)
+	return nil
 }
 
-func (it *Window) SetResizable(resizable bool) {
-	C.window_set_resizable(C.int(it.ID), toCBool(resizable))
+func (w *Window) SetResizable(resizable bool) {
+	core.Dispatch(func() {
+		C.window_set_resizable(C.int(w.ID), toCBool(resizable))
+	})
 }
 
-func (m *module) SetAlwaysOnTop(w *Window, always bool) {
+func (m *module) SetAlwaysOnTop(h core.Handle, always bool) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetAlwaysOnTop(always)
+	return nil
 }
 
-func (it *Window) SetAlwaysOnTop(always bool) {
-	C.window_set_always_on_top(C.int(it.ID), toCBool(always))
+func (w *Window) SetAlwaysOnTop(always bool) {
+	core.Dispatch(func() {
+		C.window_set_always_on_top(C.int(w.ID), toCBool(always))
+	})
 }
 
-func (m *module) SetPosition(w *Window, position Position) {
+func (m *module) SetPosition(h core.Handle, position core.Position) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetPosition(position)
+	return nil
 }
 
-func (it *Window) SetPosition(position Position) {
-	arg := C.Position{x: C.double(position.X), y: C.double(position.Y)}
-	C.window_set_position(C.int(it.ID), arg)
+func (w *Window) SetPosition(position core.Position) {
+	core.Dispatch(func() {
+		arg := C.Position{x: C.double(position.X), y: C.double(position.Y)}
+		C.window_set_position(C.int(w.ID), arg)
+	})
 }
 
-func (m *module) SetTitle(w *Window, title string) {
+func (m *module) SetTitle(h core.Handle, title string) error {
+	w := m.FindByID(h)
+	if w == nil {
+		return ErrBadHandle
+	}
 	w.SetTitle(title)
+	return nil
 }
 
-func (it *Window) SetTitle(title string) {
-	success := C.window_set_title(C.int(it.ID), C.CString(title))
-	if toBool(success) {
-		it.Title = title
+func (w *Window) SetTitle(title string) {
+	ret := make(chan bool)
+	core.Dispatch(func() {
+		ret <- fromCBool(C.window_set_title(C.int(w.ID), C.CString(title)))
+	})
+	if <-ret {
+		w.Title = title
 	}
 }
 
-func (m *module) GetOuterPosition(w *Window) Position {
-	return w.GetOuterPosition()
+func (m *module) GetOuterPosition(h core.Handle) (core.Position, error) {
+	w := m.FindByID(h)
+	if w == nil {
+		return core.Position{}, ErrBadHandle
+	}
+	return w.GetOuterPosition(), nil
 }
 
-func (it *Window) GetOuterPosition() Position {
-	result := C.window_get_outer_position(C.int(it.ID))
-	return Position{X: float64(result.x), Y: float64(result.y)}
+func (w *Window) GetOuterPosition() core.Position {
+	ret := make(chan core.Position)
+	core.Dispatch(func() {
+		result := C.window_get_outer_position(C.int(w.ID))
+		ret <- core.Position{X: float64(result.x), Y: float64(result.y)}
+	})
+	return <-ret
 }
 
-func (m *module) GetOuterSize(w *Window) Size {
-	return w.GetOuterSize()
+func (m *module) GetOuterSize(h core.Handle) (core.Size, error) {
+	w := m.FindByID(h)
+	if w == nil {
+		return core.Size{}, ErrBadHandle
+	}
+	return w.GetOuterSize(), nil
 }
 
-func (it *Window) GetOuterSize() Size {
-	result := C.window_get_outer_size(C.int(it.ID))
-	return Size{Width: float64(result.width), Height: float64(result.height)}
+func (w *Window) GetOuterSize() core.Size {
+	ret := make(chan core.Size)
+	core.Dispatch(func() {
+		result := C.window_get_outer_size(C.int(w.ID))
+		ret <- core.Size{Width: float64(result.width), Height: float64(result.height)}
+	})
+	return <-ret
 }
 
 func toCBool(it bool) C.uchar {
@@ -339,6 +469,6 @@ func toCBool(it bool) C.uchar {
 	return C.uchar(0)
 }
 
-func toBool(it C.uchar) bool {
+func fromCBool(it C.uchar) bool {
 	return int(it) != 0
 }

--- a/client/client.go
+++ b/client/client.go
@@ -1,9 +1,16 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"io"
+	"log"
+	"sync"
 
 	"github.com/progrium/qtalk-go/codec"
+	"github.com/progrium/qtalk-go/rpc"
 	"github.com/progrium/qtalk-go/talk"
 )
 
@@ -12,6 +19,32 @@ type Client struct {
 
 	Window *WindowModule
 	Screen *ScreenModule
+
+	files sync.Map
+}
+
+func (c *Client) ServeData(d []byte) string {
+	hash := sha1.New()
+	hash.Write(d)
+	selector := hex.EncodeToString(hash.Sum(nil))
+	dd, existed := c.files.LoadOrStore(selector, d)
+	if !existed {
+		c.Handle(selector, rpc.HandlerFunc(func(resp rpc.Responder, call *rpc.Call) {
+			call.Receive(nil)
+			ch, err := resp.Continue(nil)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			defer ch.Close()
+			buf := bytes.NewBuffer(dd.([]byte))
+			if _, err := io.Copy(ch, buf); err != nil {
+				log.Println(err)
+				return
+			}
+		}))
+	}
+	return selector
 }
 
 func Dial(addr string) (*Client, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,31 @@
 package client
 
-// - manager to find, start, connect to hostbridge
-// - rpc client to bridge modules
+import (
+	"context"
+
+	"github.com/progrium/qtalk-go/codec"
+	"github.com/progrium/qtalk-go/talk"
+)
+
+type Client struct {
+	*talk.Peer
+
+	Window *WindowModule
+	Screen *ScreenModule
+}
+
+func Dial(addr string) (*Client, error) {
+	peer, err := talk.Dial("tcp", addr, codec.JSONCodec{})
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{Peer: peer}
+	client.Window = &WindowModule{client: client}
+	client.Screen = &ScreenModule{client: client}
+	resp, err := client.Call(context.Background(), "Listen", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	go dispatchEvents(client, resp)
+	return client, nil
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -14,7 +14,6 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
 	go func() {
 		m.Run()
 		core.Quit()
@@ -22,18 +21,24 @@ func TestMain(m *testing.M) {
 	core.Run(nil)
 }
 
+func TestClient(t *testing.T) {
+	t.Run("window", testWindowModule)
+	t.Run("screen", testScreenModule)
+}
+
 func setupBridgeClient(t *testing.T) (*Client, func()) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
 	srv := bridge.NewServer()
 	go srv.Serve(l)
 
 	client, err := Dial(l.Addr().String())
 	if err != nil {
-		t.Fatal(err)
+		panic(err)
 	}
+
 	return client, func() {
 		client.Close()
 		l.Close()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -38,6 +38,7 @@ func setupBridgeClient(t *testing.T) (*Client, func()) {
 	if err != nil {
 		panic(err)
 	}
+	go client.Respond()
 
 	return client, func() {
 		client.Close()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"net"
+	"runtime"
+	"testing"
+
+	"github.com/progrium/hostbridge/bridge"
+	"github.com/progrium/hostbridge/bridge/core"
+)
+
+func init() {
+	runtime.LockOSThread()
+}
+
+func TestMain(m *testing.M) {
+	// call flag.Parse() here if TestMain uses flags
+	go func() {
+		m.Run()
+		core.Quit()
+	}()
+	core.Run(nil)
+}
+
+func setupBridgeClient(t *testing.T) (*Client, func()) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := bridge.NewServer()
+	go srv.Serve(l)
+
+	client, err := Dial(l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, func() {
+		client.Close()
+		l.Close()
+	}
+}

--- a/client/events.go
+++ b/client/events.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/progrium/qtalk-go/rpc"
+)
+
+type EventType int
+
+const (
+	EventNone EventType = iota
+	EventClose
+	EventDestroyed
+	EventFocused
+	EventResized
+	EventMoved
+	EventMenuItem
+	EventShortcut
+)
+
+func (e EventType) String() string {
+	return []string{"none", "close", "destroyed", "focused", "resized", "moved", "menu-item", "shortcut"}[e]
+}
+
+type Event struct {
+	Type     EventType
+	Name     string
+	WindowID Handle
+	Position Position
+	Size     Size
+	MenuID   uint16
+	Shortcut string
+}
+
+func dispatchEvents(client *Client, resp *rpc.Response) {
+	var e Event
+	for {
+		err := resp.Receive(&e)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println(err) // TODO: something else?
+			}
+			return
+		}
+		switch e.Type {
+		case EventMoved:
+			w := client.Window.byID(e.WindowID)
+			if w != nil && w.OnMoved != nil {
+				w.OnMoved(e)
+			}
+		case EventResized:
+			w := client.Window.byID(e.WindowID)
+			if w != nil && w.OnResized != nil {
+				w.OnResized(e)
+			}
+		}
+		// TODO: more cases
+	}
+}

--- a/client/screen.go
+++ b/client/screen.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"context"
+
+	"github.com/progrium/qtalk-go/fn"
+)
+
+type Display struct {
+	Name        string
+	Size        Size
+	Position    Position
+	ScaleFactor float64
+}
+
+type ScreenModule struct {
+	client *Client
+}
+
+// Destroy
+func (m *ScreenModule) Displays(ctx context.Context) (ret []Display, err error) {
+	_, err = m.client.Call(ctx, "screen.Displays", fn.Args{}, &ret)
+	return
+}

--- a/client/screen_test.go
+++ b/client/screen_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestScreenModule(t *testing.T) {
+func testScreenModule(t *testing.T) {
 	client, cleanup := setupBridgeClient(t)
 	defer cleanup()
 

--- a/client/screen_test.go
+++ b/client/screen_test.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestScreenModule(t *testing.T) {
+	client, cleanup := setupBridgeClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	d, err := client.Screen.Displays(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(d)
+
+}

--- a/client/window.go
+++ b/client/window.go
@@ -33,6 +33,7 @@ type WindowOptions struct {
 	Transparent bool
 	Visible     bool
 	Center      bool
+	IconSel     string
 	Icon        []byte
 	URL         string
 	HTML        string
@@ -57,6 +58,10 @@ func (ws *WindowModule) byID(id Handle) *Window {
 }
 
 func (s *WindowModule) New(ctx context.Context, opts WindowOptions) (*Window, error) {
+	if len(opts.Icon) > 0 {
+		opts.IconSel = s.client.ServeData(opts.Icon)
+		opts.Icon = nil
+	}
 	var win Window
 	_, err := s.client.Call(ctx, "window.New", fn.Args{opts}, &win)
 	if err != nil {

--- a/client/window.go
+++ b/client/window.go
@@ -1,0 +1,184 @@
+package client
+
+import (
+	"context"
+	"sync"
+
+	"github.com/progrium/qtalk-go/fn"
+)
+
+type Handle int
+
+type Position struct {
+	X float64
+	Y float64
+}
+
+type Size struct {
+	Width  float64
+	Height float64
+}
+
+type WindowOptions struct {
+	AlwaysOnTop bool
+	Frameless   bool
+	Fullscreen  bool
+	Size        Size
+	MinSize     Size
+	MaxSize     Size
+	Maximized   bool
+	Position    Position
+	Resizable   bool
+	Title       string
+	Transparent bool
+	Visible     bool
+	Center      bool
+	Icon        []byte
+	URL         string
+	HTML        string
+	Script      string
+}
+
+type WindowModule struct {
+	client  *Client
+	windows []*Window
+	mu      sync.Mutex
+}
+
+func (ws *WindowModule) byID(id Handle) *Window {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	for _, w := range ws.windows {
+		if w.ID == id {
+			return w
+		}
+	}
+	return nil
+}
+
+func (s *WindowModule) New(ctx context.Context, opts WindowOptions) (*Window, error) {
+	var win Window
+	_, err := s.client.Call(ctx, "window.New", fn.Args{opts}, &win)
+	if err != nil {
+		return nil, err
+	}
+	win.client = s.client
+	s.mu.Lock()
+	s.windows = append(s.windows, &win)
+	s.mu.Unlock()
+	return &win, nil
+}
+
+type Window struct {
+	client *Client
+
+	ID Handle
+
+	OnMoved     func(event Event)
+	OnResized   func(event Event)
+	OnClose     func(event Event)
+	OnFocused   func(event Event)
+	OnDestroyed func(event Event)
+}
+
+// Destroy
+func (w *Window) Destroy(ctx context.Context) (err error) {
+	_, err = w.client.Call(ctx, "window.Destroy", fn.Args{w.ID}, nil)
+	return
+}
+
+// Focus
+func (w *Window) Focus(ctx context.Context) (err error) {
+	_, err = w.client.Call(ctx, "window.Focus", fn.Args{w.ID}, nil)
+	return
+}
+
+// GetOuterPosition
+func (w *Window) GetOuterPosition(ctx context.Context) (ret Position, err error) {
+	_, err = w.client.Call(ctx, "window.GetOuterPosition", fn.Args{w.ID}, &ret)
+	return
+}
+
+// GetOuterSize
+func (w *Window) GetOuterSize(ctx context.Context) (ret Size, err error) {
+	_, err = w.client.Call(ctx, "window.GetOuterSize", fn.Args{w.ID}, &ret)
+	return
+}
+
+// IsDestroyed
+func (w *Window) IsDestroyed(ctx context.Context, size Size) (ret bool, err error) {
+	_, err = w.client.Call(ctx, "window.IsDestroyed", fn.Args{w.ID, size}, &ret)
+	return
+}
+
+// IsVisible
+func (w *Window) IsVisible(ctx context.Context) (ret bool, err error) {
+	_, err = w.client.Call(ctx, "window.IsVisible", fn.Args{w.ID}, &ret)
+	return
+}
+
+// SetVisible
+func (w *Window) SetVisible(ctx context.Context, visible bool) (err error) {
+	_, err = w.client.Call(ctx, "window.SetVisible", fn.Args{w.ID, visible}, nil)
+	return
+}
+
+// SetMaximized
+func (w *Window) SetMaximized(ctx context.Context, maximized bool) (err error) {
+	_, err = w.client.Call(ctx, "window.SetMaximized", fn.Args{w.ID, maximized}, nil)
+	return
+}
+
+// SetMinimized
+func (w *Window) SetMinimized(ctx context.Context, minimized bool) (err error) {
+	_, err = w.client.Call(ctx, "window.SetMinimized", fn.Args{w.ID, minimized}, nil)
+	return
+}
+
+// SetFullscreen
+func (w *Window) SetFullscreen(ctx context.Context, fullscreen bool) (err error) {
+	_, err = w.client.Call(ctx, "window.SetFullscreen", fn.Args{w.ID, fullscreen}, nil)
+	return
+}
+
+// SetMinSize
+func (w *Window) SetMinSize(ctx context.Context, size Size) (err error) {
+	_, err = w.client.Call(ctx, "window.SetMinSize", fn.Args{w.ID, size}, nil)
+	return
+}
+
+// SetMaxSize
+func (w *Window) SetMaxSize(ctx context.Context, size Size) (err error) {
+	_, err = w.client.Call(ctx, "window.SetMaxSize", fn.Args{w.ID, size}, nil)
+	return
+}
+
+// SetResizable
+func (w *Window) SetResizable(ctx context.Context, resizable bool) (err error) {
+	_, err = w.client.Call(ctx, "window.SetResizable", fn.Args{w.ID, resizable}, nil)
+	return
+}
+
+// SetAlwaysOnTop
+func (w *Window) SetAlwaysOnTop(ctx context.Context, always bool) (err error) {
+	_, err = w.client.Call(ctx, "window.SetAlwaysOnTop", fn.Args{w.ID, always}, nil)
+	return
+}
+
+// SetSize
+func (w *Window) SetSize(ctx context.Context, size Size) (err error) {
+	_, err = w.client.Call(ctx, "window.SetSize", fn.Args{w.ID, size}, nil)
+	return
+}
+
+// SetPosition
+func (w *Window) SetPosition(ctx context.Context, pos Position) (err error) {
+	_, err = w.client.Call(ctx, "window.SetPosition", fn.Args{w.ID, pos}, nil)
+	return
+}
+
+// SetTitle
+func (w *Window) SetTitle(ctx context.Context, title string) (err error) {
+	_, err = w.client.Call(ctx, "window.SetTitle", fn.Args{w.ID, title}, nil)
+	return
+}

--- a/client/window_test.go
+++ b/client/window_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestWindowModule(t *testing.T) {
+func testWindowModule(t *testing.T) {
 	client, cleanup := setupBridgeClient(t)
 	defer cleanup()
 
@@ -52,4 +52,5 @@ func TestWindowModule(t *testing.T) {
 
 	fmt.Println(w1, w2)
 	// time.Sleep(5 * time.Second)
+
 }

--- a/client/window_test.go
+++ b/client/window_test.go
@@ -3,6 +3,9 @@ package client
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"path"
+	"runtime"
 	"testing"
 )
 
@@ -12,8 +15,16 @@ func testWindowModule(t *testing.T) {
 
 	ctx := context.Background()
 
+	_, filename, _, _ := runtime.Caller(0)
+	iconpath := path.Join(path.Dir(filename), "../assets/icon.png")
+	icon, err := ioutil.ReadFile(iconpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	opts := WindowOptions{
 		Visible: true,
+		Icon:    icon,
 		HTML: `
 			<!doctype html>
 			<html>

--- a/client/window_test.go
+++ b/client/window_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestWindowModule(t *testing.T) {
+	client, cleanup := setupBridgeClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	opts := WindowOptions{
+		Visible: true,
+		HTML: `
+			<!doctype html>
+			<html>
+				<body style="font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif; background-color:rgba(87,87,87,0.8);"></body>
+				<script>
+					window.onload = function() {
+						document.body.innerHTML = '<div style="padding: 30px">TEST</div>';
+					};
+				</script>
+			</html>
+		`,
+	}
+	w1, err := client.Window.New(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w1.OnMoved = func(e Event) {
+		fmt.Println("MOVED:", e.Position)
+	}
+	w1.OnResized = func(e Event) {
+		fmt.Println("RESIZED:", e.Size)
+	}
+	w1.SetSize(ctx, Size{Width: 1240, Height: 480})
+	w1.SetTitle(ctx, "WINDOW1")
+	w1.SetPosition(ctx, Position{X: 200, Y: 50})
+
+	w2, err := client.Window.New(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w2.SetSize(ctx, Size{Width: 640, Height: 48})
+	w2.SetTitle(ctx, "WINDOW2")
+	w2.SetPosition(ctx, Position{X: 200, Y: 100})
+
+	w1.Focus(ctx)
+
+	fmt.Println(w1, w2)
+	// time.Sleep(5 * time.Second)
+}

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -59,7 +59,7 @@ func tick(event core.Event) {
 }
 
 func main() {
-	go main2()
+	main2()
 	core.Run(tick)
 
 	// NOTE(nick): this doesn't appear to be called ever

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -6,16 +6,21 @@ import (
 	"runtime"
 
 	"github.com/progrium/hostbridge/bridge/app"
+	"github.com/progrium/hostbridge/bridge/core"
 	"github.com/progrium/hostbridge/bridge/menu"
 	"github.com/progrium/hostbridge/bridge/screen"
 	"github.com/progrium/hostbridge/bridge/shell"
 	"github.com/progrium/hostbridge/bridge/window"
 )
 
+func init() {
+	runtime.LockOSThread()
+}
+
 var quitId uint16 = 999
 var quitAllId uint16 = 9999
 
-func tick(event app.Event) {
+func tick(event core.Event) {
 	if event.Type > 0 {
 		fmt.Println("[tick] event", event)
 
@@ -25,11 +30,11 @@ func tick(event app.Event) {
 				w.Destroy()
 			}
 
-			all := window.Module.All()
+			all := window.All()
 			fmt.Println("count of all windows", len(all))
 			if len(all) == 0 {
 				fmt.Println("  quitting application...")
-				app.Quit()
+				core.Quit()
 			}
 		}
 
@@ -39,21 +44,29 @@ func tick(event app.Event) {
 				w.Destroy()
 			}
 
-			all := window.Module.All()
+			all := window.All()
 			fmt.Println("count of all windows", len(all))
 			if len(all) == 0 {
 				fmt.Println("  quitting application...")
-				app.Quit()
+				core.Quit()
 			}
 		}
 
 		if event.Name == "menu-item" && event.MenuID == quitAllId {
-			app.Quit()
+			core.Quit()
 		}
 	}
 }
 
 func main() {
+	go main2()
+	core.Run(tick)
+
+	// NOTE(nick): this doesn't appear to be called ever
+	fmt.Println("[main] Goodbye.")
+}
+
+func main2() {
 	menuTemplate := []menu.Item{
 		{
 			// NOTE(nick): when setting the window menu with wry, the first item title will always be the name of the executable on MacOS
@@ -143,8 +156,8 @@ func main() {
 		Title: "Demo window",
 		// NOTE(nick): resizing a transparent window on MacOS seems really slow?
 		Transparent: true,
-		Frameless: false,
-		Visible: true,
+		Frameless:   false,
+		Visible:     true,
 		//Position: window.Position{X: 10, Y: 10},
 		//Size: window.Size{ Width: 360, Height: 240 },
 		Center: true,
@@ -161,7 +174,7 @@ func main() {
 		`,
 	}
 
-	w1, _ := window.Module.Create(options)
+	w1, _ := window.New(options)
 
 	fmt.Println("[main] window", w1)
 
@@ -232,8 +245,4 @@ func main() {
 	didUnregister := shell.UnregisterShortcut("Control+Shift+T")
 	fmt.Println("didUnregister", didUnregister)
 
-	app.Run(tick)
-
-	// NOTE(nick): this doesn't appear to be called ever
-	fmt.Println("[main] Goodbye.", w1)
 }

--- a/cmd/hostbridge/main.go
+++ b/cmd/hostbridge/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -25,5 +26,5 @@ func main() {
 		log.Fatal(err)
 	}
 	srv := bridge.NewServer()
-	srv.Respond(sess)
+	srv.Respond(sess, context.Background())
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
-	github.com/progrium/qtalk-go v0.5.1-0.20220217225312-a29547650bdf // indirect
+	github.com/progrium/qtalk-go v0.5.1-0.20220217235404-f7ad88d73ae2 // indirect
 	github.com/rs/xid v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20210420210106-798c2154c571 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/progrium/qtalk-go v0.5.0 h1:4ZWIWQtDuYx/l89Jyf//xQWbomoctA/7mTkMj588g
 github.com/progrium/qtalk-go v0.5.0/go.mod h1:vBfnZmpi9OTX/xNKQ6VOeq6uiaG3B4mhXI39K62bvn8=
 github.com/progrium/qtalk-go v0.5.1-0.20220217225312-a29547650bdf h1:TVNgeCp3a8lFsyTKL1xeLg1wB/HRc0wDhaqhF/v1lJc=
 github.com/progrium/qtalk-go v0.5.1-0.20220217225312-a29547650bdf/go.mod h1:iUsmFliIv4xjVAbIsrfhOSKrf83tQqOLP+oAvaexKiw=
+github.com/progrium/qtalk-go v0.5.1-0.20220217235404-f7ad88d73ae2 h1:z8LoibDqKq73brwDZNsE2dtClA/kL3+oyax1xqjVrt8=
+github.com/progrium/qtalk-go v0.5.1-0.20220217235404-f7ad88d73ae2/go.mod h1:iUsmFliIv4xjVAbIsrfhOSKrf83tQqOLP+oAvaexKiw=
 github.com/rs/xid v1.3.0 h1:6NjYksEUlhurdVehpc7S7dk6DAmcKv8V9gG0FsVN2U4=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 golang.org/x/net v0.0.0-20210420210106-798c2154c571 h1:Q6Bg8xzKzpFPU4Oi1sBnBTHBwlMsLeEXpu4hYBY8rAg=


### PR DESCRIPTION
besides setting up Module structs in each bridge package that can be exported via qtalk, I moved the dispatch mechanism into the functions that call C code. this means you can't really call Run to start the loop after using any of the APIs because they'll block until the loop starts and processes the dispatchQueue. this works fine when using the RPC frontend, but i wanted to make sure the main_static debug program still worked. so I set it up more like RPC/tests where the majority of the main code runs in a goroutine and then the eventloop is started immediately on the main thread. unfortunately, this leads to a race condition where sometimes the program will crash, but i'm not exactly sure why. it always stops at C.run as if it has to do with the event loop, but that could just be as far as the stacktrace can get. 

another interesting issue is with tests. the client tests work fine run separately, but once you run them together it dies. they are using the same event loop (since we can't stop it without exiting) but i don't see what the problem could be. running either of these tests separately is fine:

`go test -v ./client -run Screen`
`go test -v ./client -run Window`

but its hard to see if maybe i screwed up some references when cleaning things up. 

although theres lots of changes, the important thing is that any eventloop code in app was moved into core, along with some types that couldn't live anywhere else without cyclical dependencies.