### PR TITLE
add window.Focused() method

### DIFF
--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -21,7 +21,7 @@ type module struct {
 	windows    []Window
 	shouldQuit bool
 
-	FocusedWindowID Handle
+	focusedWindowID Handle
 }
 
 type Position struct {
@@ -89,7 +89,7 @@ const (
 )
 
 func (e EventType) String() string {
-	return []string{"none", "close", "destroy", "focus", "blur", "resize", "move", "menu-item", "shortcut"}[e]
+	return []string{"none", "close", "destroy", "focus", "blur", "resize", "move", "menu", "shortcut"}[e]
 }
 
 type Event struct {
@@ -134,14 +134,17 @@ func Focused() *Window {
 }
 
 func (m *module) Focused() *Window {
-	if m.FocusedWindowID > 0 {
-		return &m.windows[m.FocusedWindowID]
+	if m.focusedWindowID >= 0 {
+		return m.FindByID(m.focusedWindowID)
 	}
 
 	return nil
 }
 
 func (m *module) ProcessEvent(event Event) {
+	if event.Type == EventFocused {
+		m.focusedWindowID = event.WindowID
+	}
 }
 
 func (m *module) FindIndexByID(windowID Handle) int {

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -20,6 +20,8 @@ type module struct {
 
 	windows    []Window
 	shouldQuit bool
+
+	FocusedWindowID Handle
 }
 
 type Position struct {
@@ -72,6 +74,34 @@ type Options struct {
 	Script      string
 }
 
+type EventType int
+
+const (
+	EventNone EventType = iota
+	EventClose
+	EventDestroyed
+	EventFocused
+	EventBlurred
+	EventResized
+	EventMoved
+	EventMenuItem
+	EventShortcut
+)
+
+func (e EventType) String() string {
+	return []string{"none", "close", "destroy", "focus", "blur", "resize", "move", "menu-item", "shortcut"}[e]
+}
+
+type Event struct {
+	Type     EventType
+	Name     string
+	WindowID Handle
+	Position Position
+	Size     Size
+	MenuID   uint16
+	Shortcut string
+}
+
 var EventLoop C.EventLoop
 var Module *module
 
@@ -97,6 +127,21 @@ func (m *module) All() (result []Window) {
 	}
 
 	return result
+}
+
+func Focused() *Window {
+	return Module.Focused()
+}
+
+func (m *module) Focused() *Window {
+	if m.FocusedWindowID > 0 {
+		return &m.windows[m.FocusedWindowID]
+	}
+
+	return nil
+}
+
+func (m *module) ProcessEvent(event Event) {
 }
 
 func (m *module) FindIndexByID(windowID Handle) int {

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -15,7 +15,7 @@ import (
 var quitId uint16 = 999
 var quitAllId uint16 = 9999
 
-func tick(event app.Event) {
+func tick(event window.Event) {
 	if event.Type > 0 {
 		fmt.Println("[tick] event", event)
 
@@ -25,7 +25,7 @@ func tick(event app.Event) {
 				w.Destroy()
 			}
 
-			all := window.Module.All()
+			all := window.All()
 			fmt.Println("count of all windows", len(all))
 			if len(all) == 0 {
 				fmt.Println("  quitting application...")
@@ -39,7 +39,7 @@ func tick(event app.Event) {
 				w.Destroy()
 			}
 
-			all := window.Module.All()
+			all := window.All()
 			fmt.Println("count of all windows", len(all))
 			if len(all) == 0 {
 				fmt.Println("  quitting application...")

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -17,7 +17,7 @@ var quitAllId uint16 = 9999
 
 func tick(event window.Event) {
 	if event.Type > 0 {
-		fmt.Println("[tick] event", event)
+		fmt.Println("[tick] event", event, window.Focused())
 
 		if event.Name == "close" {
 			w := window.Module.FindByID(event.WindowID)
@@ -33,7 +33,7 @@ func tick(event window.Event) {
 			}
 		}
 
-		if event.Name == "menu-item" && event.MenuID == quitId {
+		if event.Name == "menu" && event.MenuID == quitId {
 			w := window.Module.FindByID(event.WindowID)
 			if w != nil {
 				w.Destroy()
@@ -47,7 +47,7 @@ func tick(event window.Event) {
 			}
 		}
 
-		if event.Name == "menu-item" && event.MenuID == quitAllId {
+		if event.Name == "menu" && event.MenuID == quitAllId {
 			app.Quit()
 		}
 	}
@@ -161,6 +161,11 @@ func main() {
 		`,
 	}
 
+	w2, _ := window.Module.Create(options)
+	window.Module.SetTitle(w2, "YO!")
+	//window.Module.SetFullscreen(w2, true)
+	window.Module.SetSize(w2, window.Size{ Width: 1080, Height: 720 })
+
 	w1, _ := window.Module.Create(options)
 
 	fmt.Println("[main] window", w1)
@@ -171,15 +176,6 @@ func main() {
 
 	w1.SetTitle("Hello, Sailor!")
 	fmt.Println("[main] window position", w1.GetOuterPosition())
-
-	/*
-		w2, _ := window.Module.Create(options)
-		window.Module.SetTitle(w2, "YO!")
-		window.Module.SetFullscreen(w2, true)
-
-		wasDestroyed := window.Module.Destroy(w2)
-		fmt.Println("[main] wasDestroyed", wasDestroyed)
-	*/
 
 	shell.ShowNotification(shell.Notification{
 		Title:    "Title: Hello, world",

--- a/lib/hostbridge.h
+++ b/lib/hostbridge.h
@@ -30,10 +30,11 @@ typedef enum EventType {
 	EventClose     = 1,
 	EventDestroyed = 2,
 	EventFocused   = 3,
-	EventResized   = 4,
-	EventMoved     = 5,
-	EventMenuItem  = 6,
-	EventShortcut  = 7,
+	EventBlurred   = 4,
+	EventResized   = 5,
+	EventMoved     = 6,
+	EventMenuItem  = 7,
+	EventShortcut  = 8,
 } EventType;
 
 typedef struct Event {

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -1017,9 +1017,14 @@ pub extern "C" fn run(event_loop: CEventLoop, user_callback: unsafe extern "C" f
 				let event_type = match event {
 					WindowEvent::CloseRequested{ .. } => CEventType::Close as i32,
 					WindowEvent::Destroyed{ .. }      => CEventType::Destroyed as i32,
-					WindowEvent::Focused(focus) => {
+					WindowEvent::Focused(mut focus) => {
 
-						println!("[rust] window event {:?}", focus);
+						// NOTE(nick): the "focus" argument _should_ be according to the docs:
+						// > The parameter is true if the window has gained focus, and false if it has lost focus.
+						// But in reality the _opposite_ seems to be true at the moment on win32
+						if cfg!(windows) {
+							focus = !focus; // @Hack
+						}
 
 						if focus {
 							CEventType::Focused as i32

--- a/lib/hostbridge/src/lib.rs
+++ b/lib/hostbridge/src/lib.rs
@@ -49,10 +49,11 @@ enum CEventType {
 	Close     = 1,
 	Destroyed = 2,
 	Focused   = 3,
-	Resized   = 4,
-	Moved     = 5,
-	MenuItem  = 6,
-	Shortcut  = 7,
+	Blurred   = 4,
+	Resized   = 5,
+	Moved     = 6,
+	MenuItem  = 7,
+	Shortcut  = 8,
 }
 
 #[repr(C)]
@@ -600,7 +601,7 @@ pub extern "C" fn menu_add_item(mut menu: CMenu, item: CMenu_Item) -> CBool {
 
 	let accel_str = str_from_cstr(item.accelerator);
 	if accel_str.len() > 0 {
-		let (ok, id, accelerator) = register_shortcut(accel_str, item.id);
+		let (ok, _, accelerator) = register_shortcut(accel_str, item.id);
 
 		if ok {
 			let accelerator = accelerator.unwrap();
@@ -667,7 +668,7 @@ pub extern "C" fn context_menu_add_item(mut menu: CContextMenu, item: CMenu_Item
 
 	let accel_str = str_from_cstr(item.accelerator);
 	if accel_str.len() > 0 {
-		let (ok, id, accelerator) = register_shortcut(accel_str, item.id);
+		let (ok, _, accelerator) = register_shortcut(accel_str, item.id);
 
 		if ok {
 			let accelerator = accelerator.unwrap();
@@ -1016,7 +1017,16 @@ pub extern "C" fn run(event_loop: CEventLoop, user_callback: unsafe extern "C" f
 				let event_type = match event {
 					WindowEvent::CloseRequested{ .. } => CEventType::Close as i32,
 					WindowEvent::Destroyed{ .. }      => CEventType::Destroyed as i32,
-					WindowEvent::Focused{ .. }        => CEventType::Focused as i32,
+					WindowEvent::Focused(focus) => {
+
+						println!("[rust] window event {:?}", focus);
+
+						if focus {
+							CEventType::Focused as i32
+						} else {
+							CEventType::Blurred as i32
+						}
+					},
 					WindowEvent::Resized{ .. }        => CEventType::Resized as i32,
 					WindowEvent::Moved{ .. }          => CEventType::Moved as i32,
 					_ => CEventType::None as i32,


### PR DESCRIPTION
Added a `blur` event for windows

Ideally the `Focused()` method would be an OS call (or at least a wry call) rather than keeping track in the Go layer. But at the moment wry doesn't expose anything for querying the window states. For example the current bug with it is if you close one window, the 2nd window won't get the `focus` event until you click it so `window.Focused()` will return nil during that time.

According to Electron:

> **BrowserWindow.getFocusedWindow()**
> Returns BrowserWindow | null - The window that is focused in this application, otherwise returns null

It's actually a little bit unclear if they mean _actively_ focused or _last_ focused. Would have to try it out to see

EDIT: electron only returns a window when your application is in focus, otherwise the method returns `null` even if you have open backgrounded windows