### PR TITLE
fix double lock on window Destroy

### DIFF
--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -202,8 +202,6 @@ func (m *module) Destroy(h core.Handle) (bool, error) {
 }
 
 func (w *Window) Destroy() bool {
-	w.mu.Lock()
-	defer w.mu.Unlock()
 	if w.destroyed {
 		return false
 	}
@@ -213,6 +211,7 @@ func (w *Window) Destroy() bool {
 		return false
 	}
 	w.destroyed = true
+	
 	index := Module.FindIndexByID(w.ID)
 	if index >= 0 {
 		Module.mu.Lock()

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -202,6 +202,8 @@ func (m *module) Destroy(h core.Handle) (bool, error) {
 }
 
 func (w *Window) Destroy() bool {
+	w.mu.Lock()
+
 	if w.destroyed {
 		return false
 	}
@@ -210,8 +212,11 @@ func (w *Window) Destroy() bool {
 	if !fromCBool(success) {
 		return false
 	}
+
 	w.destroyed = true
-	
+
+	w.mu.Unlock()
+
 	index := Module.FindIndexByID(w.ID)
 	if index >= 0 {
 		Module.mu.Lock()

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -202,16 +202,19 @@ func (m *module) Destroy(h core.Handle) (bool, error) {
 }
 
 func (w *Window) Destroy() bool {
+	w.mu.Lock()
+
 	if w.destroyed {
+		w.mu.Unlock()
 		return false
 	}
 
 	success := C.window_destroy(C.int(w.ID))
 	if !fromCBool(success) {
+		w.mu.Unlock()
 		return false
 	}
 
-	w.mu.Lock()
 	w.destroyed = true
 	w.mu.Unlock()
 

--- a/bridge/window/window.go
+++ b/bridge/window/window.go
@@ -202,8 +202,6 @@ func (m *module) Destroy(h core.Handle) (bool, error) {
 }
 
 func (w *Window) Destroy() bool {
-	w.mu.Lock()
-
 	if w.destroyed {
 		return false
 	}
@@ -213,8 +211,8 @@ func (w *Window) Destroy() bool {
 		return false
 	}
 
+	w.mu.Lock()
 	w.destroyed = true
-
 	w.mu.Unlock()
 
 	index := Module.FindIndexByID(w.ID)
@@ -223,6 +221,7 @@ func (w *Window) Destroy() bool {
 		Module.windows = append(Module.windows[:index], Module.windows[index+1:]...)
 		Module.mu.Unlock()
 	}
+
 	return true
 }
 

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -30,14 +30,17 @@ func tick(event core.Event) {
 				w.Destroy()
 			}
 
+			/*
 			all := window.All()
 			fmt.Println("count of all windows", len(all))
 			if len(all) == 0 {
 				fmt.Println("  quitting application...")
 				core.Quit()
 			}
+			*/
 		}
 
+		/*
 		if event.Name == "menu-item" && event.MenuID == quitId {
 			w := window.Module.FindByID(event.WindowID)
 			if w != nil {
@@ -51,6 +54,7 @@ func tick(event core.Event) {
 				core.Quit()
 			}
 		}
+		*/
 
 		if event.Name == "menu-item" && event.MenuID == quitAllId {
 			core.Quit()
@@ -185,14 +189,9 @@ func main2() {
 	w1.SetTitle("Hello, Sailor!")
 	fmt.Println("[main] window position", w1.GetOuterPosition())
 
-	/*
-		w2, _ := window.Module.Create(options)
-		window.Module.SetTitle(w2, "YO!")
-		window.Module.SetFullscreen(w2, true)
-
-		wasDestroyed := window.Module.Destroy(w2)
-		fmt.Println("[main] wasDestroyed", wasDestroyed)
-	*/
+	w2, _ := window.New(options)
+	w2.SetTitle("YO!")
+	w2.SetSize(core.Size{ Width: 640, Height: 480 })
 
 	shell.ShowNotification(shell.Notification{
 		Title:    "Title: Hello, world",

--- a/cmd/ffi-debug/main_static.go
+++ b/cmd/ffi-debug/main_static.go
@@ -30,17 +30,14 @@ func tick(event core.Event) {
 				w.Destroy()
 			}
 
-			/*
 			all := window.All()
 			fmt.Println("count of all windows", len(all))
 			if len(all) == 0 {
 				fmt.Println("  quitting application...")
 				core.Quit()
 			}
-			*/
 		}
 
-		/*
 		if event.Name == "menu-item" && event.MenuID == quitId {
 			w := window.Module.FindByID(event.WindowID)
 			if w != nil {
@@ -54,7 +51,6 @@ func tick(event core.Event) {
 				core.Quit()
 			}
 		}
-		*/
 
 		if event.Name == "menu-item" && event.MenuID == quitAllId {
 			core.Quit()
@@ -189,9 +185,9 @@ func main2() {
 	w1.SetTitle("Hello, Sailor!")
 	fmt.Println("[main] window position", w1.GetOuterPosition())
 
-	w2, _ := window.New(options)
-	w2.SetTitle("YO!")
-	w2.SetSize(core.Size{ Width: 640, Height: 480 })
+	w3, _ := window.New(options)
+	w3.SetTitle("YO!")
+	w3.SetSize(core.Size{ Width: 640, Height: 480 })
 
 	shell.ShowNotification(shell.Notification{
 		Title:    "Title: Hello, world",


### PR DESCRIPTION
if you close the backgrounded window first ("Hello, Sailor!"), then Go throws an error:

> fatal error: sync: unlock of unlocked mutex

it seems like removing the window from `Module.windows` also calls the window mutex unlock

so we need to rework `window.Destroy` a little bit so we don't get the exception